### PR TITLE
Feat: Add support for user-defined languages

### DIFF
--- a/src/main/store/module/preferences.ts
+++ b/src/main/store/module/preferences.ts
@@ -12,6 +12,7 @@ export default new Store<PreferencesStore>({
   cwd: 'v2',
 
   defaults: {
+    customLanguages: [],
     storagePath: defaultPath,
     backupPath,
     theme: 'light:chrome',

--- a/src/renderer/components/preferences/CustomLanguagePreferences.vue
+++ b/src/renderer/components/preferences/CustomLanguagePreferences.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="custom-language-preferences">
+    <div>
+      <em>Custom Languages provide access to filetypes outside of the included
+        languages. This can be used for custom filetype support in vim or other
+        editors. The surrogate language is used for syntax highlighting in the
+        editor. It makes the custom filetype look like the selected
+        language.</em>
+    </div>
+    <AppForm>
+      <ul>
+        <li
+          v-for="(customLanguage, index) in customLanguages"
+          :key="index"
+        >
+          <div>
+            <h4>
+              {{
+                customLanguages[index].name.length > 0
+                  ? customLanguages[index].name
+                  : 'New'
+              }}
+            </h4>
+            <AppFormItem label="Name">
+              <AppInput
+                v-model="customLanguages[index].name"
+                @change="
+                  onUpdateCustomLanguage('name', $event.target.value, index)
+                "
+              />
+            </AppFormItem>
+            <AppFormItem label="Value">
+              <AppInput
+                v-model="customLanguages[index].value"
+                @change="
+                  onUpdateCustomLanguage('value', $event.target.value, index)
+                "
+              />
+            </AppFormItem>
+            <AppFormItem label="Surrogate Language">
+              <AppSelect
+                v-model="customLanguages[index].surrogate"
+                :options="languageOptions"
+                @change="
+                  onUpdateCustomLanguage(
+                    'surrogate',
+                    $event.target.value,
+                    index
+                  )
+                "
+              />
+            </AppFormItem>
+            <AppFormItem label="">
+              <AppButton @click="removeCustomLanguage(index)">
+                Remove Option
+              </AppButton>
+            </AppFormItem>
+          </div>
+        </li>
+      </ul>
+      <AppFormItem label="">
+        <AppButton @click="onNewCustomLanguage">
+          Add New Custom Language
+        </AppButton>
+      </AppFormItem>
+    </AppForm>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { usePreferencesStore } from '@/store/preferences'
+import { languages } from '../../components/editor/languages'
+
+const preferencesStore = usePreferencesStore()
+const languageOptions = languages.reduce(
+  (acc, option) => [...acc, { label: option.name, value: option.value }],
+  [{ label: 'No Surrogate', value: '' }]
+)
+
+const customLanguages = preferencesStore.customLanguages
+
+const onNewCustomLanguage = () => {
+  customLanguages.push({ name: '', value: '' })
+}
+
+const onUpdateCustomLanguage = (key, value, index) => {
+  customLanguages[index][key] = value
+  preferencesStore.upsertCustomLanguage(customLanguages[index], index)
+}
+
+const removeCustomLanguage = (index: number) => {
+  preferencesStore.removeCustomLanguage(index)
+}
+</script>
+
+<style lang="scss" scoped>
+ul {
+  list-style: none;
+  margin-top: 0;
+  padding-left: 0;
+
+  li {
+    .form-item {
+      padding-bottom: 1em;
+    }
+  }
+}
+</style>

--- a/src/renderer/store/preferences.ts
+++ b/src/renderer/store/preferences.ts
@@ -1,0 +1,24 @@
+import { store } from '@/electron'
+import { defineStore } from 'pinia'
+import { toRaw } from 'vue'
+
+import type { State } from '@shared/types/renderer/store/preferences'
+import type { LanguageOption } from '@shared/types/renderer/editor'
+
+export const usePreferencesStore = defineStore('preferences', {
+  state: (): State => ({
+    customLanguages: store.preferences.get('customLanguages') || []
+  }),
+
+  actions: {
+    upsertCustomLanguage (language: LanguageOption, index: number) {
+      this.customLanguages[index] = language
+      store.preferences.set('customLanguages', toRaw(this.customLanguages))
+    },
+    removeCustomLanguage (index: number) {
+      this.customLanguages.splice(index, 1)
+
+      store.preferences.set('customLanguages', toRaw(this.customLanguages))
+    }
+  }
+})

--- a/src/renderer/views/Preferences.vue
+++ b/src/renderer/views/Preferences.vue
@@ -26,6 +26,12 @@
         >
           <AppearancePreferences />
         </AppMenuItem>
+        <AppMenuItem
+          name="Custom Languages"
+          value="customLanguages"
+        >
+          <CustomLanguagePreferences />
+        </AppMenuItem>
       </AppMenu>
     </div>
   </div>

--- a/src/shared/types/main/store.d.ts
+++ b/src/shared/types/main/store.d.ts
@@ -1,5 +1,6 @@
 import type { EditorSettings, ScreenshotSettings } from '../renderer/store/app'
 import type { SnippetsSort } from './db'
+import type { LanguageOption } from '../renderer/editor'
 
 export interface AppStore {
   bounds: object
@@ -16,6 +17,7 @@ export interface AppStore {
 }
 
 export interface PreferencesStore {
+  customLanguages: LanguageOption[]
   storagePath: string
   backupPath: string
   editor: EditorSettings

--- a/src/shared/types/renderer/store/preferences.d.ts
+++ b/src/shared/types/renderer/store/preferences.d.ts
@@ -1,0 +1,5 @@
+import type { LanguageOption } from '@shared/types/renderer/editor'
+
+export interface State {
+  customLanguages: LanguageOption[]
+}


### PR DESCRIPTION
I've been working on creating a vim extension to hook into this project. Vim has many more extensible language and filetype options than what is hard-coded here and even allows defining filetypes on the fly. This PR adds a new preferences pane for defining custom languages that the editor can hook to obtain snippets. It also allows setting a "Surrogate Language" for the custom languages so that syntax highlighting works in the snippet editor.