### PR TITLE
chore(i18n): fix several spanish translations

### DIFF
--- a/src/main/services/i18n/locales/es_ES/common.json
+++ b/src/main/services/i18n/locales/es_ES/common.json
@@ -10,7 +10,7 @@
   },
   "newFolder": "Nueva Carpeta",
   "newSnippet": "Nuevo Snippet",
-  "newFragment": "Nuevo Fragment",
+  "newFragment": "Nuevo Fragmento",
   "addDescription": "Agregar Descripción",
   "addToFavorites": "Agregar a Favoritos",
   "addTag": "Agregar Etiqueta",

--- a/src/main/services/i18n/locales/es_ES/menu.json
+++ b/src/main/services/i18n/locales/es_ES/menu.json
@@ -61,7 +61,7 @@
     "label": "Editor",
     "copy": "Copiar Snippet al Portapapeles",
     "format": "Formato",
-    "previewMarkdown": "Pre-visualizar en Markdown",
+    "previewMarkdown": "Previsualizar en Markdown",
     "previewCode": "Previsualizar Código",
     "previewScreenshot": "Previsualizar Captura de Pantalla"
   }

--- a/src/main/services/i18n/locales/es_ES/menu.json
+++ b/src/main/services/i18n/locales/es_ES/menu.json
@@ -61,8 +61,8 @@
     "label": "Editor",
     "copy": "Copiar Snippet al Portapapeles",
     "format": "Formato",
-    "previewMarkdown": "Pré-visualizar en Markdown",
-    "previewCode": "Pré-visualizar Codigo",
-    "previewScreenshot": "Pré-visualizar Captura de Pantalla"
+    "previewMarkdown": "Pre-visualizar en Markdown",
+    "previewCode": "Previsualizar Código",
+    "previewScreenshot": "Previsualizar Captura de Pantalla"
   }
 }

--- a/src/main/services/i18n/locales/es_ES/special.json
+++ b/src/main/services/i18n/locales/es_ES/special.json
@@ -18,7 +18,7 @@
   "error": {
     "folderNotContainDb": "La carpeta no contiene \"db.json\"."
   },
-  "unsponsored": "Sin Patrocinio",
+  "unsponsored": "Sin Patrocinar",
   "supportMessage": "Hola, soy Anton 👋<br><br>\nGracias por usar massCode. Si encuentras útil esta aplicación, por favor {{-tagStart}} dona {{-tagEnd}}. Me inspirará a continuar desarrollando este proyecto.",
   "snippetsShowcase": "Muestra de Snippets"
 }


### PR DESCRIPTION
Also noticed that `Untitled snippet` does not get translated:

![image](https://user-images.githubusercontent.com/23016174/183122166-1f4ac5e5-1638-4ac2-8f6b-ccbff07f3da3.png)

I may find time during the weekend to resolve this small issue if you wish.
