### PR TITLE
feat(keymap): add `cmd+` / `cmd-` to control editor font size

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -48,6 +48,7 @@ import {
   useSupportNotification,
   checkForRemoteNotification
 } from '@/composable/notification'
+import { useKeyMap } from '@/composable/keymap'
 
 // По какой то причине необходимо явно установить роут в '/'
 // для корректного поведения в продакшен сборке
@@ -97,6 +98,7 @@ const init = async () => {
 
   trackAppUpdate()
   checkForRemoteNotification()
+  useKeyMap()
 }
 
 const setTheme = (theme: string) => {

--- a/src/renderer/components/editor/EditorCodemirror.vue
+++ b/src/renderer/components/editor/EditorCodemirror.vue
@@ -323,6 +323,7 @@ watch(
 )
 
 emitter.on('snippet:format', () => format())
+emitter.on('editor:refresh', () => editor.refresh())
 
 onMounted(() => {
   init()
@@ -330,6 +331,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   emitter.off('snippet:format')
+  emitter.off('editor:refresh')
 })
 </script>
 

--- a/src/renderer/composable/keymap.ts
+++ b/src/renderer/composable/keymap.ts
@@ -1,0 +1,45 @@
+import { store } from '@/electron'
+import { EDITOR_DEFAULTS, useAppStore } from '@/store/app'
+import { useMagicKeys } from '@vueuse/core'
+import { watch } from 'vue'
+import router from '@/router'
+import { emitter } from '.'
+
+export const useKeyMap = () => {
+  const appStore = useAppStore()
+
+  // Вариант с meta.value && Equal.value вызывается только один раз,
+  // последующее нажатие на клавишу "="" не вызывает метод.
+  // Поэтому сделал так
+  useMagicKeys({
+    passive: false,
+    onEventFired: e => {
+      const { path } = router.currentRoute.value
+
+      if (path !== '/') return
+
+      if (e.metaKey && e.key === '=') {
+        appStore.editor.fontSize += 1
+      }
+
+      if (e.metaKey && e.key === '-') {
+        if (appStore.editor.fontSize === 1) return
+        appStore.editor.fontSize -= 1
+      }
+
+      if (e.metaKey && e.key === '0') {
+        appStore.editor.fontSize = EDITOR_DEFAULTS.fontSize
+      }
+
+      emitter.emit('editor:refresh', true)
+    }
+  })
+
+  watch(
+    () => appStore.editor,
+    v => {
+      store.preferences.set('editor', { ...v })
+    },
+    { deep: true }
+  )
+}

--- a/src/renderer/store/app.ts
+++ b/src/renderer/store/app.ts
@@ -10,7 +10,7 @@ import type {
 import { defineStore } from 'pinia'
 import { version } from '../../../package.json'
 
-const EDITOR_DEFAULTS: EditorSettings = {
+export const EDITOR_DEFAULTS: EditorSettings = {
   fontFamily: 'SF Mono, Consolas, Menlo, Ubuntu Mono, monospace',
   fontSize: 12,
   tabSize: 2,

--- a/src/shared/types/renderer/composable/index.d.ts
+++ b/src/shared/types/renderer/composable/index.d.ts
@@ -7,4 +7,5 @@ export type EmitterEvents = {
   'scroll-to:folder': string
   'scroll-to:snippet': string
   'search:focus': boolean
+  'editor:refresh': boolean
 }


### PR DESCRIPTION
Implementation of the idea #208