### PR TITLE
Added "Always Show Fragments" name in the preferences of your Editor

### DIFF
--- a/src/main/services/i18n/locales/en/preferences.json
+++ b/src/main/services/i18n/locales/en/preferences.json
@@ -19,6 +19,7 @@
     "highlightLine": "Highlight Line",
     "highlightGutter": "Highlight Gutter",
     "matchBrackets": "Match Brackets",
+    "showFragments": "Always Show Fragments",
     "prettier": {
       "label": "Prettier",
       "trailingComma": {

--- a/src/main/store/module/preferences.ts
+++ b/src/main/store/module/preferences.ts
@@ -25,7 +25,8 @@ export default new Store<PreferencesStore>({
       singleQuote: true,
       highlightLine: false,
       highlightGutter: false,
-      matchBrackets: false
+      matchBrackets: false,
+      showFragments: false
     },
     screenshot: {
       background: false,

--- a/src/renderer/components/preferences/EditorPreferences.vue
+++ b/src/renderer/components/preferences/EditorPreferences.vue
@@ -37,6 +37,12 @@
           name="matchBrackets"
         />
       </AppFormItem>
+      <AppFormItem :label="i18n.t('preferences:editor.showFragments')">
+        <AppCheckbox
+          v-model="appStore.editor.showFragments"
+          name="showFragments"
+        />
+      </AppFormItem>
       <h4>{{ i18n.t('preferences:editor.prettier.label') }}</h4>
       <AppFormItem
         :label="i18n.t('preferences:editor.prettier.trailingComma.label')"

--- a/src/renderer/store/app.ts
+++ b/src/renderer/store/app.ts
@@ -21,7 +21,8 @@ export const EDITOR_DEFAULTS: EditorSettings = {
   singleQuote: true,
   highlightLine: false,
   highlightGutter: false,
-  matchBrackets: false
+  matchBrackets: false,
+  showFragments: false
 }
 
 const SCREENSHOT_DEFAULTS: ScreenshotSettings = {

--- a/src/renderer/store/snippets.ts
+++ b/src/renderer/store/snippets.ts
@@ -81,7 +81,9 @@ export const useSnippetStore = defineStore('snippets', {
     fragmentCount: state => state.selected?.content?.length,
     tagsCount: state => state.selected?.tagsIds?.length,
     isFragmentsShow (): boolean {
-      return this.fragmentCount ? this.fragmentCount > 1 : false
+      const appStore = useAppStore()
+      if (appStore.editor.showFragments === true) return true
+      else return this.fragmentCount ? this.fragmentCount > 1 : false
     },
     isTagsShow (): boolean {
       const appStore = useAppStore()

--- a/src/shared/types/renderer/store/app.d.ts
+++ b/src/shared/types/renderer/store/app.d.ts
@@ -37,6 +37,7 @@ export interface EditorSettings {
   highlightLine: boolean
   highlightGutter: boolean
   matchBrackets: boolean
+  showFragments: boolean
 }
 
 export interface ScreenshotSettings {


### PR DESCRIPTION
Added a new feature that allows you to always show the name of the Fragment even when there is only one fragment in the snippet item. I use the name of the fragment when I am sharing the code snippet with others and it is helpful to be able to nae the fragment when you are creating it instead of having to do that after the you export the fragment. The preferences under the Editor section defaults to false so that the current functionality remains in place unless you choose to "Always Show Fragments". 

![image](https://github.com/massCodeIO/massCode/assets/39595991/72375551-3a10-457c-b592-f0d03e54442e)

If the "Always Show Fragment" is set to true then snippets with only 1 fragment will show the fragment name.

![image](https://github.com/massCodeIO/massCode/assets/39595991/43d1366f-f80a-4962-b124-b5167162cb68)


### What kind of change does this PR introduce?

> check at least one

- [X] Feature

### Validations

- [X] Follow our [CONTRIBUTING](https://github.com/massCodeIO/massCode/blob/master/CONTRIBUTING.md) guide
