### PR TITLE
Update README.md to remove raycast extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
 <p align="center">
   Extensions:
   <a href="https://marketplace.visualstudio.com/items?itemName=AntonReshetov.masscode-assistant">VS Code</a> |
-  <a href="https://www.raycast.com/antonreshetov/masscode">Raycast</a> |
   <a href="https://github.com/massCodeIO/assistant-alfred">Alfred</a>
 </p>
 


### PR DESCRIPTION
no longer a valid extension url

### What kind of change does this PR introduce?

> check at least one


- [x] Other, please describe:
Remove outdated url to raycast masscode extension
### Validations

- [ ] Follow our [CONTRIBUTING](https://github.com/massCodeIO/massCode/blob/master/CONTRIBUTING.md) guide
