### PR TITLE
feat: widen padding at sidebar top

### DIFF
--- a/src/renderer/components/sidebar/TheSidebar.vue
+++ b/src/renderer/components/sidebar/TheSidebar.vue
@@ -242,7 +242,7 @@ watch(
 
 <style lang="scss" scoped>
 .sidebar {
-  padding-top: var(--title-bar-height);
+  padding-top: calc(var(--title-bar-height) * 1.675);
   position: relative;
   background-color: var(--color-sidebar);
   display: flex;


### PR DESCRIPTION
### What kind of change does this PR introduce?

> check at least one

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Other, please describe:

### Validations

- [x] Follow our [CONTRIBUTING](https://github.com/massCodeIO/massCode/blob/master/CONTRIBUTING.md) guide

---

I can't speak for other platforms, but on macOS the default placement of the sidebar is much too close to the window buttons for comfort. I've accidentally minimized/maximized my massCode window by misclicking because of the narrow space in between the "Library / Tags" button and the window controls.

<img width="189" alt="Before" src="https://github.com/user-attachments/assets/c1c9429b-245e-45f0-967b-b46517cfe2bb" />

This pull request increases the padding to better separate the in-app controls from the system window controls. Eg. after:

<img width="190" alt="After" src="https://github.com/user-attachments/assets/62868cb8-e509-4d41-899c-872b19295939" />

