### PR TITLE
fix: Some languages not detected when importing from SnippetsLab

### DIFF
--- a/src/main/services/db/index.ts
+++ b/src/main/services/db/index.ts
@@ -453,6 +453,17 @@ export const migrateFromSnippetsLabNew = (path: string) => {
   console.log('Migrate is done')
 }
 
+const SL_STATIC_LANG_MAPPING: Record<string, Language> = {
+  'bash': 'sh',
+  'batch': 'batchfile',
+  'c': 'c_cpp',
+  'coffeescript': 'coffee',
+  'cpp': 'c_cpp',
+  'docker': 'dockerfile',
+  'go': 'golang',
+  'graphql': 'graphqlschema',
+}
+
 const convertSLLanguage = (
   language: string,
   languages: LanguageOption[],
@@ -462,10 +473,11 @@ const convertSLLanguage = (
     language = language.replace(/Lexer$/, '')
   }
 
-  if (language.toLowerCase() === 'bash') {
-    language = 'sh'
-  }
+  language = SL_STATIC_LANG_MAPPING[language.toLowerCase()] || language
 
-  const _language = snakeCase(language.toLowerCase())
-  return languages.find(i => i.value === _language)?.value || 'plain_text'
+  const match = languages.find(i => {
+    return i.value === snakeCase(language) ||
+      i.value === language.toLowerCase()
+  })
+  return match?.value || 'plain_text'
 }


### PR DESCRIPTION
While taking massCode for a test drive, I noticed all my shell script snippets that were imported from a SnippetsLab JSON file had been marked as plain text.

The problem is that "Bash" (via "BashLexer") does not match the "sh" that massCode expects. Similarly, massCode expects "golang" instead of "Go".

This is a quick PR to fix a few of those cases.

Note: A good future task might be to check if there are other languages with this same problem by checking each of [Pygments supported languages' Lexer class names](https://pygments.org/languages/) (which is what SnippetsLab is using under-the-hood) against the [list massCode's language IDs](https://github.com/massCodeIO/massCode/blob/834eb28693b8262982a3ea1fc57f5ba948bd8411/src/shared/types/renderer/editor/index.d.ts).

### What kind of change does this PR introduce?

> check at least one

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Other, please describe:

### Validations

- [x] Follow our [CONTRIBUTING](https://github.com/massCodeIO/massCode/blob/master/CONTRIBUTING.md) guide
