### PR TITLE
fix: prevent remote access to API by binding to localhost

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,1 +1,2 @@
 export const API_PORT = 3033
+export const API_HOST = '127.0.0.1'

--- a/src/main/services/api/server.ts
+++ b/src/main/services/api/server.ts
@@ -1,7 +1,7 @@
 import * as jsonServer from '@masscode/json-server'
 import { store } from '../../store'
 import { nanoid } from 'nanoid'
-import { API_PORT } from '../../config'
+import { API_PORT, API_HOST } from '../../config'
 import path from 'path'
 import type { DB, Folder, Snippet, Tag } from '@shared/types/main/db'
 import type { Server } from 'http'
@@ -132,7 +132,7 @@ export class ApiServer {
 
     app.use(router)
 
-    const server = app.listen(API_PORT, () => {
+    const server = app.listen(API_PORT, API_HOST, () => {
       console.log(`API server is running on port ${API_PORT}`)
     }) as ServerWithDestroy
 


### PR DESCRIPTION
### What kind of change does this PR introduce?
Security improvement

This PR updates the API server configuration to bind only to 127.0.0.1, restricting access to localhost.

Previously, the API could listen on all interfaces (0.0.0.0), which allowed remote connections. Since massCode snippets may contain sensitive or private data, this could pose a serious security risk — especially in environments where a firewall is not enabled or improperly configured. Binding to localhost ensures that only local applications can access the API.
