### PR TITLE
chore: updated README to tweak wording for macos troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ This will start the application with hot reloading.
 
 ### macOS
 
-If you encounter the error message "massCode" is damaged and can't be opened. You should move it to the Trash while installing software on macOS, it may be due to security settings restrictions in macOS.
+If you encounter the error message `"massCode" is damaged and can't be opened. You should move it to the Trash` while installing software on macOS, it may be due to security settings restrictions in macOS. The macOS build is unsigned, so Gatekeeper is trying to restrict access to it. 
 
 **Option 1: System Settings (macOS 13+)**
 1. Open **System Settings** → **Privacy & Security**
@@ -170,7 +170,9 @@ If you encounter the error message "massCode" is damaged and can't be opened. Yo
 3. Click **Allow Anyway** or **Open Anyway**
 4. You may need to enter your administrator password
 
-**Option 2: Terminal command**
+**Option 2: Terminal Command**
+This works on all versions of macOS, but since macOS Tahoe (macOS 26) the **Open Anyway** dialog (option 1) may not appear, so it could be the only option.
+
 ```bash
 sudo xattr -r -d com.apple.quarantine /Applications/massCode.app
 ```


### PR DESCRIPTION
### What kind of change does this PR introduce?

> check at least one

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [x] Other, please describe: docs

### Validations

- [x] Follow our [CONTRIBUTING](https://github.com/massCodeIO/massCode/blob/master/CONTRIBUTING.md) guide


Wrapped the message in snippet quotes as it read as if the remedy was "you should move it to the trash".

Added a note about tahoe (macos 26) as I am not seeing the open anyway dialog any more since updating to that. This is anecdotal so somebody else may correct me if they are still seeing option 1 work.