### PR TITLE
fix(storage): recover legacy snippet fences

### DIFF
--- a/src/main/storage/providers/markdown/runtime/__tests__/parser.test.ts
+++ b/src/main/storage/providers/markdown/runtime/__tests__/parser.test.ts
@@ -2,6 +2,7 @@ import type { MarkdownSnippet } from '../types'
 import { describe, expect, it } from 'vitest'
 import {
   parseBodyFragments,
+  parseBodyFragmentsWithMetadata,
   serializeSnippet,
   splitFrontmatter,
 } from '../parser'
@@ -38,5 +39,82 @@ describe('parser snippet content roundtrip', () => {
 
     expect(parsed).toHaveLength(1)
     expect(parsed[0].value).toBe(input)
+  })
+})
+
+describe('legacy snippet fence recovery', () => {
+  it('recovers a legacy triple-backtick wrapper with inner fenced blocks', () => {
+    const body = [
+      '## Fragment: Fragment 1',
+      '```markdown',
+      'Before',
+      '```',
+      'inner block',
+      '```',
+      'After',
+      '```',
+      '',
+    ].join('\n')
+
+    const result = parseBodyFragmentsWithMetadata(body, [
+      {
+        id: 1,
+        label: 'Fragment 1',
+        language: 'markdown',
+      },
+    ])
+
+    expect(result.legacyRecovery).toBe('recovered')
+    expect(result.fragments).toHaveLength(1)
+    expect(result.fragments[0].value).toBe(
+      ['Before', '```', 'inner block', '```', 'After'].join('\n'),
+    )
+  })
+
+  it('uses declared fragments instead of user text that looks like a fragment heading', () => {
+    const body = [
+      '## Fragment: Fragment 1',
+      '```markdown',
+      'Intro',
+      '## Fragment: Fragment 2',
+      '```plain_text',
+      'not a fragment boundary',
+      '```',
+      'Outro',
+      '```',
+      '',
+      '## Fragment: Fragment 2',
+      '```javascript',
+      'console.log("second")',
+      '```',
+      '',
+    ].join('\n')
+
+    const result = parseBodyFragmentsWithMetadata(body, [
+      {
+        id: 1,
+        label: 'Fragment 1',
+        language: 'markdown',
+      },
+      {
+        id: 2,
+        label: 'Fragment 2',
+        language: 'javascript',
+      },
+    ])
+
+    expect(result.legacyRecovery).toBe('recovered')
+    expect(result.fragments).toHaveLength(2)
+    expect(result.fragments[0].value).toBe(
+      [
+        'Intro',
+        '## Fragment: Fragment 2',
+        '```plain_text',
+        'not a fragment boundary',
+        '```',
+        'Outro',
+      ].join('\n'),
+    )
+    expect(result.fragments[1].value).toBe('console.log("second")')
   })
 })

--- a/src/main/storage/providers/markdown/runtime/__tests__/snippets.test.ts
+++ b/src/main/storage/providers/markdown/runtime/__tests__/snippets.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { readSnippetFromFile } from '../snippets'
+import { resetRuntimeCache, syncRuntimeWithDisk } from '../sync'
 
 vi.mock('electron-store', () => {
   class MockStore {
@@ -80,6 +81,8 @@ function createPaths(): Paths {
 }
 
 afterEach(() => {
+  resetRuntimeCache()
+
   for (const dirPath of tempDirs.splice(0)) {
     fs.removeSync(dirPath)
   }
@@ -170,5 +173,87 @@ describe('readSnippetFromFile', () => {
     finally {
       vi.useRealTimers()
     }
+  })
+
+  it('recovers legacy triple-backtick snippets without rewriting on direct read', () => {
+    const paths = createPaths()
+    const relativePath = '.masscode/inbox/legacy-fence-snippet.md'
+    const absolutePath = path.join(paths.vaultPath, relativePath)
+    const source = [
+      '---',
+      'id: 12',
+      'name: Legacy Fence Snippet',
+      'contents:',
+      '  - id: 1',
+      '    label: Fragment 1',
+      '    language: markdown',
+      '---',
+      '',
+      '## Fragment: Fragment 1',
+      '```markdown',
+      'Before',
+      '```',
+      'inner block',
+      '```',
+      'After',
+      '```',
+      '',
+    ].join('\n')
+
+    fs.ensureDirSync(path.dirname(absolutePath))
+    fs.writeFileSync(absolutePath, source, 'utf8')
+
+    const snippet = readSnippetFromFile(
+      paths,
+      { filePath: relativePath, id: 12 },
+      new Map(),
+    )
+
+    expect(snippet?.contents[0].value).toBe(
+      ['Before', '```', 'inner block', '```', 'After'].join('\n'),
+    )
+    expect(fs.readFileSync(absolutePath, 'utf8')).toBe(source)
+  })
+
+  it('rewrites recovered legacy snippets during primary runtime sync', () => {
+    const paths = createPaths()
+    const relativePath = '.masscode/inbox/legacy-fence-snippet.md'
+    const absolutePath = path.join(paths.vaultPath, relativePath)
+    const source = [
+      '---',
+      'id: 13',
+      'name: Legacy Fence Snippet',
+      'createdAt: 1',
+      'updatedAt: 1',
+      'contents:',
+      '  - id: 1',
+      '    label: Fragment 1',
+      '    language: markdown',
+      '---',
+      '',
+      '## Fragment: Fragment 1',
+      '```markdown',
+      'Before',
+      '```',
+      'inner block',
+      '```',
+      'After',
+      '```',
+      '',
+    ].join('\n')
+
+    fs.ensureDirSync(path.dirname(absolutePath))
+    fs.writeFileSync(absolutePath, source, 'utf8')
+
+    const cache = syncRuntimeWithDisk(paths)
+    const rewrittenSource = fs.readFileSync(absolutePath, 'utf8')
+
+    expect(cache.snippets[0].contents[0].value).toBe(
+      ['Before', '```', 'inner block', '```', 'After'].join('\n'),
+    )
+    expect(rewrittenSource).toContain('````markdown')
+    expect(rewrittenSource).toContain(
+      ['Before', '```', 'inner block', '```', 'After'].join('\n'),
+    )
   })
 })

--- a/src/main/storage/providers/markdown/runtime/parser.ts
+++ b/src/main/storage/providers/markdown/runtime/parser.ts
@@ -2,6 +2,7 @@ import type { FolderRecord } from '../../../contracts'
 import type {
   MarkdownBodyFragment,
   MarkdownFolderMetadataFile,
+  MarkdownFrontmatterContent,
   MarkdownSnippet,
   MarkdownSnippetFrontmatter,
   Paths,
@@ -132,20 +133,59 @@ export function splitFrontmatter(source: string): {
   }
 }
 
-export function parseBodyFragments(body: string): MarkdownBodyFragment[] {
+interface BodyFragmentParseResult {
+  fragments: MarkdownBodyFragment[]
+  legacyRecovery: 'ambiguous' | 'none' | 'recovered'
+}
+
+interface StrictBodyFragmentParseResult {
+  fragments: MarkdownBodyFragment[]
+  lastCursor: number
+}
+
+function getFenceLength(line: string): number {
+  let fenceLength = 0
+
+  while (fenceLength < line.length && line.charCodeAt(fenceLength) === 96) {
+    fenceLength += 1
+  }
+
+  return fenceLength
+}
+
+function parseFragmentHeader(line: string): string | null {
+  if (!line.startsWith('## Fragment:')) {
+    return null
+  }
+
+  return line.slice('## Fragment:'.length).trim() || 'Fragment'
+}
+
+function hasNonEmptyTail(lines: string[], cursor: number): boolean {
+  for (let index = cursor; index < lines.length; index += 1) {
+    if (lines[index].trim()) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function parseBodyFragmentsStrict(body: string): StrictBodyFragmentParseResult {
   const fragments: MarkdownBodyFragment[] = []
   const lines = body.split(NEW_LINE_SPLIT_RE)
+  let lastCursor = 0
 
   let lineIndex = 0
   while (lineIndex < lines.length) {
     const line = lines[lineIndex]
+    const label = parseFragmentHeader(line)
 
-    if (!line.startsWith('## Fragment:')) {
+    if (!label) {
       lineIndex += 1
       continue
     }
 
-    const label = line.slice('## Fragment:'.length).trim() || 'Fragment'
     lineIndex += 1
 
     if (lineIndex >= lines.length) {
@@ -153,14 +193,7 @@ export function parseBodyFragments(body: string): MarkdownBodyFragment[] {
     }
 
     const fenceLine = lines[lineIndex]
-    let fenceLength = 0
-
-    while (
-      fenceLength < fenceLine.length
-      && fenceLine.charCodeAt(fenceLength) === 96
-    ) {
-      fenceLength += 1
-    }
+    const fenceLength = getFenceLength(fenceLine)
 
     if (fenceLength < 3) {
       continue
@@ -180,6 +213,7 @@ export function parseBodyFragments(body: string): MarkdownBodyFragment[] {
       lineIndex += 1
     }
 
+    lastCursor = lineIndex
     fragments.push({
       label,
       language,
@@ -195,6 +229,195 @@ export function parseBodyFragments(body: string): MarkdownBodyFragment[] {
     })
   }
 
+  return { fragments, lastCursor }
+}
+
+function findLegacyFragmentOpenings(
+  lines: string[],
+  metadata: MarkdownFrontmatterContent[],
+): number[][] {
+  return metadata.map((meta) => {
+    const openings: number[] = []
+
+    for (let index = 0; index < lines.length - 1; index += 1) {
+      const label = parseFragmentHeader(lines[index])
+      if (!label) {
+        continue
+      }
+
+      const fenceLine = lines[index + 1]
+      const fenceLength = getFenceLength(fenceLine)
+      if (fenceLength !== 3) {
+        continue
+      }
+
+      const language = fenceLine.slice(fenceLength).trim() || 'plain_text'
+      if (meta.label && label !== meta.label) {
+        continue
+      }
+
+      if (meta.language && language !== meta.language) {
+        continue
+      }
+
+      openings.push(index)
+    }
+
+    return openings
+  })
+}
+
+function buildLegacyOpeningSequences(
+  openingsByFragment: number[][],
+): number[][] {
+  const sequences: number[][] = []
+
+  function visit(
+    fragmentIndex: number,
+    previousOpening: number,
+    sequence: number[],
+  ): void {
+    if (fragmentIndex >= openingsByFragment.length) {
+      sequences.push([...sequence])
+      return
+    }
+
+    for (const openingIndex of openingsByFragment[fragmentIndex]) {
+      if (openingIndex <= previousOpening) {
+        continue
+      }
+
+      sequence.push(openingIndex)
+      visit(fragmentIndex + 1, openingIndex, sequence)
+      sequence.pop()
+    }
+  }
+
+  visit(0, -1, [])
+  return sequences
+}
+
+function parseLegacyTripleFenceFragments(
+  body: string,
+  metadata: MarkdownFrontmatterContent[],
+): BodyFragmentParseResult {
+  if (metadata.length === 0) {
+    return { fragments: [], legacyRecovery: 'none' }
+  }
+
+  const lines = body.split(NEW_LINE_SPLIT_RE)
+  const openingsByFragment = findLegacyFragmentOpenings(lines, metadata)
+  if (openingsByFragment.some(openings => openings.length === 0)) {
+    return { fragments: [], legacyRecovery: 'none' }
+  }
+
+  const firstOpening = Math.min(...openingsByFragment[0])
+  const sequences = buildLegacyOpeningSequences(openingsByFragment).filter(
+    sequence => sequence[0] === firstOpening,
+  )
+
+  const recoveredFragmentsBySignature = new Map<
+    string,
+    MarkdownBodyFragment[]
+  >()
+
+  for (const sequence of sequences) {
+    const fragments: MarkdownBodyFragment[] = []
+    let isValidSequence = true
+
+    for (let index = 0; index < sequence.length; index += 1) {
+      const openingIndex = sequence[index]
+      const nextOpeningIndex = sequence[index + 1] ?? lines.length
+      const closingCandidates: number[] = []
+
+      for (
+        let lineIndex = openingIndex + 2;
+        lineIndex < nextOpeningIndex;
+        lineIndex += 1
+      ) {
+        if (lines[lineIndex].trim() === '```') {
+          closingCandidates.push(lineIndex)
+        }
+      }
+
+      const closingIndex = closingCandidates.at(-1)
+      if (closingIndex === undefined) {
+        isValidSequence = false
+        break
+      }
+
+      const label = parseFragmentHeader(lines[openingIndex]) || 'Fragment'
+      const fenceLine = lines[openingIndex + 1]
+      const language = fenceLine.slice(3).trim() || 'plain_text'
+
+      fragments.push({
+        label,
+        language,
+        value: lines.slice(openingIndex + 2, closingIndex).join('\n'),
+      })
+    }
+
+    if (!isValidSequence) {
+      continue
+    }
+
+    recoveredFragmentsBySignature.set(JSON.stringify(fragments), fragments)
+  }
+
+  if (recoveredFragmentsBySignature.size === 1) {
+    return {
+      fragments: [...recoveredFragmentsBySignature.values()][0],
+      legacyRecovery: 'recovered',
+    }
+  }
+
+  if (recoveredFragmentsBySignature.size > 1) {
+    return { fragments: [], legacyRecovery: 'ambiguous' }
+  }
+
+  return { fragments: [], legacyRecovery: 'none' }
+}
+
+export function parseBodyFragmentsWithMetadata(
+  body: string,
+  metadata: MarkdownFrontmatterContent[],
+): BodyFragmentParseResult {
+  const strictResult = parseBodyFragmentsStrict(body)
+  const declaredFragmentCount = metadata.length
+
+  if (declaredFragmentCount === 0) {
+    return { fragments: strictResult.fragments, legacyRecovery: 'none' }
+  }
+
+  const legacyResult = parseLegacyTripleFenceFragments(body, metadata)
+  const hasSuspiciousTail
+    = strictResult.fragments.length >= declaredFragmentCount
+      && hasNonEmptyTail(body.split(NEW_LINE_SPLIT_RE), strictResult.lastCursor)
+  const hasLegacyMismatch
+    = legacyResult.legacyRecovery === 'recovered'
+      && JSON.stringify(legacyResult.fragments)
+      !== JSON.stringify(strictResult.fragments)
+
+  if (
+    strictResult.fragments.length === declaredFragmentCount
+    && !hasSuspiciousTail
+    && !hasLegacyMismatch
+  ) {
+    return { fragments: strictResult.fragments, legacyRecovery: 'none' }
+  }
+
+  if (legacyResult.legacyRecovery === 'recovered') {
+    return legacyResult
+  }
+
+  return {
+    fragments: strictResult.fragments,
+    legacyRecovery: legacyResult.legacyRecovery,
+  }
+}
+
+export function parseBodyFragments(body: string): MarkdownBodyFragment[] {
+  const { fragments } = parseBodyFragmentsStrict(body)
   return fragments
 }
 

--- a/src/main/storage/providers/markdown/runtime/snippets.ts
+++ b/src/main/storage/providers/markdown/runtime/snippets.ts
@@ -21,7 +21,7 @@ import {
 } from './constants'
 import { normalizeNullableNumber, normalizeNumber } from './normalizers'
 import {
-  parseBodyFragments,
+  parseBodyFragmentsWithMetadata,
   serializeSnippet,
   splitFrontmatter,
 } from './parser'
@@ -83,6 +83,20 @@ export function readSnippetFromFile(
   entry: MarkdownSnippetIndexItem,
   pathToFolderIdMap: ReadonlyMap<string, number>,
 ): MarkdownSnippet | null {
+  return (
+    readSnippetFromFileWithMetadata(paths, entry, pathToFolderIdMap)?.snippet
+    ?? null
+  )
+}
+
+export function readSnippetFromFileWithMetadata(
+  paths: Paths,
+  entry: MarkdownSnippetIndexItem,
+  pathToFolderIdMap: ReadonlyMap<string, number>,
+): {
+  legacyRecovery: 'ambiguous' | 'none' | 'recovered'
+  snippet: MarkdownSnippet
+} | null {
   const snippetPath = path.join(paths.vaultPath, entry.filePath)
 
   if (!fs.pathExistsSync(snippetPath)) {
@@ -93,10 +107,13 @@ export function readSnippetFromFile(
   const { body, frontmatter, hasFrontmatter } = splitFrontmatter(source)
   const now = Date.now()
   const timestampFallbacks = getFileTimestampFallbacks(snippetPath, now)
-  const fragments = parseBodyFragments(body)
   const metaContents = Array.isArray(frontmatter.contents)
     ? frontmatter.contents
     : []
+  const { fragments, legacyRecovery } = parseBodyFragmentsWithMetadata(
+    body,
+    metaContents,
+  )
 
   const contents = fragments.length
     ? fragments.map((fragment, index) => {
@@ -172,17 +189,33 @@ export function readSnippetFromFile(
     writeSnippetToFile(paths, snippet)
   }
 
-  return snippet
+  return { legacyRecovery, snippet }
 }
 
 export function loadSnippets(
   paths: Paths,
   state: MarkdownState,
+  options?: { rewriteRecoveredLegacyFences?: boolean },
 ): MarkdownSnippet[] {
   const pathToFolderIdMap = buildPathToFolderIdMap(state)
 
   return state.snippets
-    .map(item => readSnippetFromFile(paths, item, pathToFolderIdMap))
+    .map((item) => {
+      const result = readSnippetFromFileWithMetadata(
+        paths,
+        item,
+        pathToFolderIdMap,
+      )
+
+      if (
+        options?.rewriteRecoveredLegacyFences
+        && result?.legacyRecovery === 'recovered'
+      ) {
+        writeSnippetToFile(paths, result.snippet)
+      }
+
+      return result?.snippet ?? null
+    })
     .filter((snippet): snippet is MarkdownSnippet => !!snippet)
 }
 

--- a/src/main/storage/providers/markdown/runtime/sync.ts
+++ b/src/main/storage/providers/markdown/runtime/sync.ts
@@ -212,7 +212,9 @@ export function resetRuntimeCache(): void {
 
 export function syncRuntimeWithDisk(paths: Paths): MarkdownRuntimeCache {
   const state = syncStateWithDisk(paths)
-  const snippets = loadSnippets(paths, state)
+  const snippets = loadSnippets(paths, state, {
+    rewriteRecoveredLegacyFences: true,
+  })
 
   return setRuntimeCache(paths, state, snippets)
 }


### PR DESCRIPTION
Recover legacy markdown snippet files that used a triple-backtick fragment wrapper when the fragment body also contains fenced code blocks. Recovered files are normalized through the existing dynamic-fence serializer during primary runtime sync.