### PR TITLE
fix(main): replace ESM-only nanoid with node:crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "markmap-view": "^0.18.10",
     "mathjs": "^15.1.1",
     "mermaid": "^11.6.0",
-    "nanoid": "^3.3.8",
     "nearest-color": "^0.4.4",
     "onigasm": "^2.2.5",
     "prettier": "^3.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,9 +173,6 @@ importers:
       mermaid:
         specifier: ^11.6.0
         version: 11.6.0
-      nanoid:
-        specifier: ^3.3.8
-        version: 3.3.8
       nearest-color:
         specifier: ^0.4.4
         version: 0.4.4

--- a/src/main/ipc/handlers/fs.ts
+++ b/src/main/ipc/handlers/fs.ts
@@ -1,5 +1,6 @@
 import type { ImportMarkdownFolderResponse } from '../../types/ipc'
 import { Buffer } from 'node:buffer'
+import { randomBytes } from 'node:crypto'
 import { extname, join, parse, relative } from 'node:path'
 import { BrowserWindow, dialog, ipcMain } from 'electron'
 import {
@@ -10,12 +11,19 @@ import {
   realpath,
   writeFileSync,
 } from 'fs-extra'
-import { nanoid } from 'nanoid'
 import slash from 'slash'
 import { ensureFlatSpacesLayout } from '../../storage/providers/markdown/runtime/spaces'
 import { store } from '../../store'
 
 const ASSETS_DIR = 'assets'
+
+// A short, URL- and filesystem-safe id for asset filenames. Uses the
+// built-in crypto module so the main process keeps no dependency on the
+// ESM-only nanoid, which cannot be `require`d from the compiled CommonJS
+// build.
+function generateAssetId() {
+  return randomBytes(12).toString('base64url')
+}
 
 async function readMarkdownFolder(
   rootPath: string,
@@ -96,7 +104,7 @@ export function registerFsHandlers() {
         const assetsPath = join(storagePath, ASSETS_DIR)
 
         const { ext } = parse(fileName)
-        const name = `${nanoid()}${ext}`
+        const name = `${generateAssetId()}${ext}`
         const dest = join(assetsPath, name)
 
         ensureDirSync(assetsPath)
@@ -122,7 +130,7 @@ export function registerFsHandlers() {
       try {
         ensureFlatSpacesLayout(vaultPath)
         const assetsPath = join(vaultPath, 'notes', 'assets')
-        const name = `${nanoid()}${ext}`
+        const name = `${generateAssetId()}${ext}`
         const dest = join(assetsPath, name)
 
         ensureDirSync(assetsPath)

--- a/src/renderer/composables/math-notebook/useMathNotebook.ts
+++ b/src/renderer/composables/math-notebook/useMathNotebook.ts
@@ -6,7 +6,6 @@ import {
 } from '@/composables/useStorageMutation'
 import { i18n, ipc } from '@/electron'
 import { useDebounceFn } from '@vueuse/core'
-import { nanoid } from 'nanoid'
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -85,7 +84,7 @@ export function useMathNotebook() {
       sheets.value.map(sheet => sheet.name),
     )
     const sheet: MathSheet = {
-      id: nanoid(),
+      id: crypto.randomUUID(),
       name: nextSheetName,
       content: '',
       createdAt: Date.now(),


### PR DESCRIPTION
## Problem

Production build crashed on launch with `ERR_REQUIRE_ESM`: the compiled CommonJS main process `require()`d `nanoid`, which resolved to an ESM-only version (`nanoid@4`, pulled in transitively by `@excalidraw/excalidraw`) once electron-builder flattened the pnpm tree into the asar. It worked in dev only because the top-level `nanoid` there was v3 (with a CJS entry).

## Fix

- `src/main/ipc/handlers/fs.ts` — generate asset filenames with the built-in `node:crypto` (`randomBytes(12).toString('base64url')`) instead of nanoid, removing the main process' dependency on the ESM-only module.
- `src/renderer/composables/math-notebook/useMathNotebook.ts` — use `crypto.randomUUID()` for sheet ids.
- Dropped `nanoid` from direct dependencies (it remains only as a transitive dependency of excalidraw/vite/postcss, which bundle it themselves).

Existing math sheet ids keep working — ids are opaque strings, old nanoid ids and new UUIDs coexist with no migration.