### PR TITLE
feat(math): add search to sheet list

### DIFF
--- a/src/main/i18n/locales/en_US/ui.json
+++ b/src/main/i18n/locales/en_US/ui.json
@@ -190,6 +190,8 @@
       "title": "Math Notebook",
       "sheetList": "Sheet List",
       "newSheet": "New Sheet",
+      "searchPlaceholder": "Search sheets…",
+      "noResults": "No sheets found",
       "untitled": "Untitled",
       "currencyUnavailable": "Currency rates service unavailable"
     },

--- a/src/renderer/components/math-notebook/SheetList.vue
+++ b/src/renderer/components/math-notebook/SheetList.vue
@@ -9,7 +9,7 @@ import {
 import { i18n } from '@/electron'
 import { onClickOutside } from '@vueuse/core'
 import { format } from 'date-fns'
-import { FileText } from 'lucide-vue-next'
+import { FileText, Search } from 'lucide-vue-next'
 
 const { isCompactListMode } = useApp()
 const {
@@ -36,13 +36,70 @@ const {
 
 const sheetListRef = ref<HTMLElement>()
 const isSheetListFocused = ref(false)
+const searchQuery = ref('')
+
+const filteredSheets = computed(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+
+  if (!query) {
+    return sheets.value
+  }
+
+  return sheets.value.filter(sheet =>
+    sheet.name.toLowerCase().includes(query),
+  )
+})
 
 function handleCreateSheet() {
+  searchQuery.value = ''
   const id = createSheet()
   const sheet = sheets.value.find(sheet => sheet.id === id)
 
   if (sheet) {
     startRename(sheet.id, sheet.name)
+  }
+}
+
+function scrollActiveSheetIntoView() {
+  nextTick(() => {
+    sheetListRef.value
+      ?.querySelector(`[data-sheet-id="${activeSheetId.value}"]`)
+      ?.scrollIntoView({ block: 'nearest' })
+  })
+}
+
+function moveSearchSelection(delta: number) {
+  const items = filteredSheets.value
+
+  if (items.length === 0) {
+    return
+  }
+
+  const currentIndex = items.findIndex(
+    item => item.id === activeSheetId.value,
+  )
+  const nextIndex
+    = currentIndex === -1
+      ? delta > 0
+        ? 0
+        : items.length - 1
+      : Math.min(Math.max(currentIndex + delta, 0), items.length - 1)
+
+  selectSheet(items[nextIndex].id)
+  scrollActiveSheetIntoView()
+}
+
+function onSearchKeydown(event: KeyboardEvent) {
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveSearchSelection(1)
+  }
+  else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveSearchSelection(-1)
+  }
+  else if (event.key === 'Escape') {
+    searchQuery.value = ''
   }
 }
 
@@ -103,9 +160,21 @@ defineExpose({
     data-math-sheets-list
     class="flex h-full flex-col overflow-hidden"
   >
+    <div class="mb-1 flex items-center px-2">
+      <Search class="text-muted-foreground ml-1 h-4 w-4 shrink-0" />
+      <div class="min-w-0 flex-grow">
+        <UiInput
+          v-model="searchQuery"
+          :placeholder="i18n.t('spaces.math.searchPlaceholder')"
+          variant="ghost"
+          class="truncate"
+          @keydown="onSearchKeydown"
+        />
+      </div>
+    </div>
     <div class="scrollbar min-h-0 flex-1 overflow-y-auto px-2">
       <ContextMenu.ContextMenu
-        v-for="sheet in sheets"
+        v-for="sheet in filteredSheets"
         :key="sheet.id"
       >
         <ContextMenu.ContextMenuTrigger as-child>
@@ -113,6 +182,7 @@ defineExpose({
             class="group mb-0.5 cursor-default transition-colors duration-75"
             :class="activeSheetId === sheet.id ? 'text-accent-foreground' : ''"
             :selected="activeSheetId === sheet.id"
+            :data-sheet-id="sheet.id"
             tabindex="-1"
             @click="(event) => selectSheetFromList(sheet.id, event)"
             @dblclick="startRename(sheet.id, sheet.name)"
@@ -181,10 +251,14 @@ defineExpose({
       </ContextMenu.ContextMenu>
 
       <div
-        v-if="sheets.length === 0"
+        v-if="filteredSheets.length === 0"
         class="text-muted-foreground mt-8 text-center text-[12px]"
       >
-        {{ i18n.t("placeholder.emptySheetList") }}
+        {{
+          searchQuery.trim()
+            ? i18n.t("spaces.math.noResults")
+            : i18n.t("placeholder.emptySheetList")
+        }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Adds search to the math sheet list, mirroring the drawings list search.

- Filter sheets by name (client-side, case-insensitive).
- Ghost search input with empty/no-results states.
- Arrow up/down navigate filtered results, scrolling the selection into view.
- Escape clears the query; creating a new sheet resets the query.

Added `spaces.math.searchPlaceholder` / `spaces.math.noResults` locale keys.