### PR TITLE
ci(mac): enable code signing and notarization

### DIFF
--- a/.github/workflows/build-sponsored.yml
+++ b/.github/workflows/build-sponsored.yml
@@ -55,6 +55,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_SPONSORED: true
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Build application (sponsored other platforms)
         if: matrix.platform != 'mac'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,11 @@ jobs:
         run: pnpm run build:${{ matrix.platform }}:${{ matrix.arch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Build application (other platforms)
         if: matrix.platform != 'mac'

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ auto-imports.d.ts
 .github/*-instructions.md
 .env
 .env.*
+electron-builder.env
 docs/superpowers
 docs/website/.vitepress/cache
 docs/website/.vitepress/dist

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -17,7 +17,7 @@
     "entitlements": "build/entitlements.mac.inherit.plist",
     "category": "public.app-category.productivity",
     "hardenedRuntime": true,
-    "identity": null
+    "notarize": true
   },
   "win": {
     "target": ["nsis", "portable"],

--- a/electron-builder.sponsored.json
+++ b/electron-builder.sponsored.json
@@ -18,7 +18,7 @@
     "entitlements": "build/entitlements.mac.inherit.plist",
     "category": "public.app-category.productivity",
     "hardenedRuntime": true,
-    "identity": null
+    "notarize": true
   },
   "win": {
     "target": ["nsis", "portable"],


### PR DESCRIPTION
Enable macOS code signing and notarization for release and sponsored builds:

- remove `identity: null` and add `notarize: true` to both electron-builder configs
- pass signing credentials (`CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`) to macOS build steps in workflows
- add `electron-builder.env` to `.gitignore`