### PR TITLE
ci: increase Node heap limit for builds

### DIFF
--- a/.github/workflows/build-sponsored.yml
+++ b/.github/workflows/build-sponsored.yml
@@ -7,6 +7,8 @@ jobs:
   build-sponsored:
     name: Build Sponsored for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Fix JavaScript heap OOM in `vite build` on CI runners by setting `NODE_OPTIONS=--max-old-space-size=4096` for build jobs in release and sponsored workflows.