### PR TITLE
ci(mac): build both architectures in a single job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-15-intel
-            platform: mac
-            arch: x64
+          # Обе архитектуры macOS собираются одной джобой: раздельные джобы
+          # затирали latest-mac.yml друг друга, ломая автообновление.
           - os: macos-15
             platform: mac
-            arch: arm64
           - os: windows-latest
             platform: win
           - os: ubuntu-latest
@@ -51,17 +49,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Rebuild native dependencies (macOS)
-        if: matrix.platform == 'mac'
-        run: pnpm run rebuild --arch ${{ matrix.arch }}
-
-      - name: Rebuild native dependencies (other platforms)
-        if: matrix.platform != 'mac'
+      - name: Rebuild native dependencies
         run: pnpm run rebuild
 
       - name: Build application (macOS)
         if: matrix.platform == 'mac'
-        run: pnpm run build:${{ matrix.platform }}:${{ matrix.arch }}
+        run: pnpm run build:mac
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -79,15 +72,15 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: masscode-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.ref_name || inputs.tag }}
+          name: masscode-${{ matrix.platform }}-${{ github.ref_name || inputs.tag }}
           path: |
             dist/*.dmg
+            dist/*.zip
             dist/*.pkg
             dist/*.exe
             dist/*.msi
             dist/*.AppImage
             dist/*.snap
-            !dist/*-sponsored.*
             !dist/*.yml
             !dist/*.blockmap
           if-no-files-found: warn

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev:main": "nodemon",
     "dev:start": "wait-on tcp:5177 build/main/index.js && cross-env NODE_ENV=development DEV_PORT=5177 electronmon .",
     "build": "vite build && npm run build:main && electron-builder",
-    "build:mac": "vite build && npm run build:main && npm run build:mac:x64 && npm run build:mac:arm64",
+    "build:mac": "vite build && npm run build:main && electron-builder --mac --x64 --arm64",
     "build:mac:x64": "vite build && npm run build:main && electron-builder --mac --x64",
     "build:mac:arm64": "vite build && npm run build:main && electron-builder --mac --arm64",
     "build:win": "vite build && npm run build:main && electron-builder --win --x64",


### PR DESCRIPTION
Separate x64/arm64 jobs were overwriting each other's `latest-mac.yml`, breaking auto-update for one of the architectures. Build both arches in one `electron-builder --mac --x64 --arm64` run on the arm64 runner, add `*.zip` to artifacts.