### PR TITLE
ci(mac): use Python 3.11 for node-gyp native rebuilds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,14 @@ jobs:
           node-version: 24.14.1
           cache: pnpm
 
+      # node-gyp внутри electron-builder требует Python с distutils (< 3.12)
+      # для кросс-архитектурной пересборки нативных модулей.
+      - name: Setup Python for node-gyp (macOS)
+        if: matrix.platform == 'mac'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
electron-builder's bundled node-gyp 9 requires Python with distutils (removed in 3.12) to rebuild native modules for the cross-architecture macOS build.