### PR TITLE
fix(drawings): reset drawings space state on vault switch

### DIFF
--- a/src/renderer/components/preferences/Storage.vue
+++ b/src/renderer/components/preferences/Storage.vue
@@ -9,6 +9,7 @@ import {
   resetHttpSpaceState,
   resetNotesSpaceInitialization,
   useDialog,
+  useDrawings,
   useFolders,
   useHttpEnvironments,
   useHttpFolders,
@@ -45,6 +46,7 @@ const { getHttpRequests } = useHttpRequests()
 const { getHttpEnvironments } = useHttpEnvironments()
 const { getHttpHistory } = useHttpHistory()
 const { reset: resetMathNotebook } = useMathNotebook()
+const { resetDrawings } = useDrawings()
 const { resetNoteFoldersState } = useNoteFolders()
 const { clearNotesState, getNotes } = useNotes()
 const { resetNoteTags } = useNoteTags()
@@ -184,6 +186,7 @@ getSnippetsCounts()
 
 async function resetAndReloadVaultData() {
   resetMathNotebook()
+  resetDrawings()
   clearNotesState()
   resetNoteFoldersState()
   resetNoteTags()

--- a/src/renderer/composables/spaces/drawings/useDrawings.ts
+++ b/src/renderer/composables/spaces/drawings/useDrawings.ts
@@ -68,6 +68,20 @@ async function loadDrawingsList() {
   drawings.value = Array.isArray(items) ? items : []
 }
 
+// Полный сброс состояния space при смене vault: очищаем список, активный
+// рисунок и кеши, иначе после переключения остаётся список старого vault,
+// так как init() выходит рано из-за уже взведённого initialized.
+function resetDrawings() {
+  drawings.value = []
+  activeDrawingId.value = null
+  activeDrawingContent.value = null
+  drawingViewports.value = {}
+  initialized = false
+  lastSavedContent = null
+  loadContentToken += 1
+  pendingContentByDrawingId.clear()
+}
+
 async function loadActiveDrawingContent() {
   const id = activeDrawingId.value
 
@@ -392,6 +406,7 @@ export function useDrawings() {
     imageExportRequest,
     init,
     markDrawingsStale,
+    resetDrawings,
     reloadFromDisk,
     selectDrawing,
     openDrawing,


### PR DESCRIPTION
При смене vault состояние space drawings не сбрасывалось в `resetAndReloadVaultData()`, поэтому после переключения оставался список рисунков из предыдущего vault: `init()` выходил рано из-за уже взведённого флага `initialized`.

Добавлен `resetDrawings()` (по образцу `resetMathNotebook`), который полностью очищает состояние space, и его вызов при смене vault.