### PR TITLE
docs: add best code snippet managers comparison page

### DIFF
--- a/docs/website/.vitepress/config.mts
+++ b/docs/website/.vitepress/config.mts
@@ -109,6 +109,7 @@ export default defineConfig({
             { text: 'massCode vs Things 3', link: '/compare/things' },
             { text: 'massCode vs Apple Reminders', link: '/compare/apple-reminders' },
             { text: 'massCode vs Obsidian Tasks', link: '/compare/obsidian-tasks' },
+            { text: 'Best Code Snippet Managers', link: '/compare/best-code-snippet-managers' },
             { text: 'Best Open-Source Snippet Manager', link: '/compare/best-open-source' },
             { text: 'Local-First Alternative to Pieces / Cacher', link: '/compare/local-first' },
             { text: 'Markdown-First Task Manager', link: '/compare/markdown-first-tasks' },

--- a/docs/website/compare/best-code-snippet-managers.md
+++ b/docs/website/compare/best-code-snippet-managers.md
@@ -1,0 +1,180 @@
+---
+title: Best Code Snippet Managers (2026)
+description: "An honest, up-to-date guide to the best code snippet managers — massCode, SnippetsLab, Pieces, Cacher, Lepton, GitHub Gist, and more. Compare them on license, storage, platforms, price, and scope, then pick the right one for your workflow."
+---
+
+# Best Code Snippet Managers
+
+A code snippet manager is where the small, reusable pieces of your work live: the regex you always forget, the boilerplate config, the shell one-liner, the query you wrote once and will need again. The right one saves those snippets in seconds and gives them back the moment you need them. The wrong one becomes another place you forget to look.
+
+This guide compares the best code snippet managers available today. Every tool here is a reasonable choice for someone — the goal is to help you match a tool to how you actually work, not to crown a single winner.
+
+## How we evaluated them
+
+Star count and marketing aside, a snippet manager is worth adopting when it handles the boring parts well. We looked at:
+
+- **Storage and ownership.** Are your snippets plain files on your disk, or rows in someone else's database? Can you read them without the app?
+- **License.** Open source you can audit and fork, or proprietary.
+- **Platforms.** macOS only, or also Windows and Linux.
+- **Price.** Free, one-time purchase, or subscription.
+- **Account requirement.** Does it work offline without signing in?
+- **Search.** Full-text search is the feature you use most and notice least.
+- **Imports.** Can it pull in your existing library, or do you start from scratch?
+- **Scope.** Snippets only, or notes, HTTP requests, and other developer tools alongside them.
+
+## At a glance
+
+| Tool | License | Platforms | Storage | Account | Scope |
+| --- | --- | --- | --- | --- | --- |
+| [massCode](#masscode) | Open source (AGPL v3) | macOS, Windows, Linux | Local Markdown files | No | Snippets + notes, HTTP, math, tools |
+| [SnippetsLab](#snippetslab) | Proprietary | macOS only | Local library | No | Snippets |
+| [Pieces](#pieces) | Proprietary | macOS, Windows, Linux + IDE/browser | On-device / local | Optional | Snippets + AI companion |
+| [Cacher](#cacher) | Proprietary | macOS, Windows, Linux | Cloud | Yes | Snippets, team libraries |
+| [Lepton](#lepton) | Open source (MIT) | macOS, Windows, Linux | GitHub Gist | GitHub | Snippets (unmaintained) |
+| [GitHub Gist](#github-gist) | Proprietary (service) | Web + API | Cloud | Yes | Snippets |
+| [Raycast Snippets](#raycast-snippets) | Proprietary | macOS, iOS | App database | Optional | Text expansion |
+| [VS Code snippets](#vs-code-snippets) | Open source (editor) | Anywhere VS Code runs | JSON in editor config | No | Snippets in-editor |
+
+Details and trade-offs for each are below.
+
+## The best code snippet managers
+
+### massCode
+
+[massCode](https://github.com/massCodeIO/massCode) is a free, open-source, local-first developer workspace. Snippets sit alongside notes, HTTP requests, math sheets, and dev tools, and everything is stored as plain Markdown files in a [Markdown Vault](/documentation/storage) on your own disk.
+
+- **License:** [AGPL v3](https://github.com/massCodeIO/massCode/blob/master/LICENSE), source on [GitHub](https://github.com/massCodeIO/massCode)
+- **Platforms:** macOS, Windows, Linux
+- **Storage:** Local `.md` files you can read, edit, and back up without the app
+- **Account:** None required, no telemetry login
+- **Search:** Full-text across snippets, notes, and HTTP requests
+- **Imports:** VS Code snippets JSON, Raycast snippets JSON, SnippetsLab JSON, public GitHub Gist URLs, and Obsidian markdown folders
+- **Sync:** Bring your own — iCloud, Dropbox, Google Drive, Syncthing, or [Git](/documentation/sync)
+
+**Best for:** developers who want their snippets to stay as plain files they own, on every platform, for free, and who appreciate having notes, HTTP requests, and math in the same window. [Download massCode](/download/) to try it.
+
+### SnippetsLab
+
+[SnippetsLab](https://www.renfei.org/snippets-lab/) is a long-standing, polished, macOS-native snippet manager. It has a refined interface, a built-in assistant for the macOS menu bar, and deep integration with the Apple ecosystem. As of 2026 its own site states it is "FREE for everyone — no ads, no in-app purchases, and no subscriptions."
+
+- **License:** Proprietary
+- **Platforms:** macOS only (macOS 13.5 or later)
+- **Price:** Free
+- **Storage:** Local library
+- **Scope:** Snippets, focused and well executed
+
+**Best for:** developers who live entirely on macOS and want a native, carefully designed snippet app at no cost. If you also use Windows or Linux, it cannot follow you there. See the full [massCode vs SnippetsLab](/compare/snippetslab) comparison.
+
+### Pieces
+
+[Pieces](https://pieces.app) is an AI-first snippet manager built around an on-device AI companion, long-term memory of your work, and tight integration with editors and browsers. Its site emphasizes that "Pieces runs on-device" and processes data locally.
+
+- **License:** Proprietary
+- **Platforms:** macOS, Windows, Linux, plus IDE and browser integrations
+- **Storage:** On-device / local processing
+- **Scope:** Snippets enriched with AI, long-term memory, multiple LLMs
+
+**Best for:** developers who want an AI assistant that remembers their work and answers questions about it. If you want a focused, file-based workspace without AI, it is more than you need. See [massCode vs Pieces](/compare/pieces).
+
+### Cacher
+
+[Cacher](https://www.cacher.io) is a cloud-based snippet organizer aimed at individuals and teams, with shared libraries, labels, and editor integrations.
+
+- **License:** Proprietary
+- **Platforms:** macOS, Windows, Linux, plus a VS Code extension
+- **Storage:** Cloud
+- **Scope:** Personal and team snippet libraries
+
+**Best for:** teams that want a hosted, shared snippet library with centralized access. If you prefer your snippets on local disk with no account, it is the opposite model. See [massCode vs Cacher](/compare/cacher).
+
+### Lepton
+
+[Lepton](https://github.com/hackjutsu/Lepton) is a lean, open-source snippet manager powered by GitHub Gist. Your snippets are stored as Gists, so they round-trip with GitHub, including GitHub Enterprise.
+
+- **License:** Open source (MIT)
+- **Platforms:** macOS, Windows, Linux
+- **Storage:** GitHub Gist (cloud)
+- **Scope:** Snippets only
+- **Maintenance:** Largely inactive — its last tagged release (v1.10.0) dates to 2021, so treat it as stable-but-unmaintained
+
+**Best for:** developers who want their snippet library to *be* their GitHub Gists and are comfortable with a project that is no longer actively developed. You trade local-file ownership for Gist sync and a narrower feature set.
+
+### GitHub Gist
+
+[GitHub Gist](https://gist.github.com) is not a dedicated app, but plenty of developers use it as one. It is free, instantly shareable, and versioned with Git.
+
+- **License:** Proprietary service
+- **Platforms:** Web and API, plus many third-party clients
+- **Storage:** Cloud (your GitHub account)
+- **Scope:** Snippets as Gists
+
+**Best for:** quick, shareable, public or secret snippets you already manage on GitHub. As a primary library it lacks folders, rich organization, and offline-first storage. If you outgrow it, massCode can [import your Gists](/documentation/code/library) by URL.
+
+### Raycast Snippets
+
+[Raycast Snippets](https://www.raycast.com) is a feature of the Raycast launcher for macOS. It is best as a global text expander you trigger from anywhere, rather than a long-form code library.
+
+- **License:** Proprietary
+- **Platforms:** macOS, iOS
+- **Storage:** Raycast database, optional cloud sync on Pro
+- **Scope:** Short text expansion
+
+**Best for:** system-wide text expansion of short snippets. Many developers pair it with a dedicated library; massCode even ships a [Raycast extension](https://www.raycast.com/antonreshetov/masscode) so you can search your massCode snippets from Raycast. See [massCode vs Raycast Snippets](/compare/raycast).
+
+### VS Code snippets
+
+VS Code has a built-in snippets feature: JSON files that expand by prefix as you type. It is free, already installed, and great for templated code you insert while writing.
+
+- **License:** Open source editor
+- **Platforms:** Anywhere VS Code runs
+- **Storage:** JSON in your editor config
+- **Scope:** In-editor expansion
+
+**Best for:** templated boilerplate you insert by prefix inside VS Code. It is not a searchable library for snippets you collect and revisit. massCode imports VS Code snippets JSON, so the two can coexist.
+
+## How to choose the right snippet manager
+
+Work through these questions before installing anything:
+
+- **Where should my snippets live?** Plain files on your disk, a hosted cloud account, or GitHub Gists?
+- **Which platforms do I use?** macOS only opens more options; cross-platform narrows the field to a few.
+- **Do I want it to work offline with no login?** If yes, rule out account-required cloud tools.
+- **Will I import an existing library?** Check that your current format (VS Code JSON, Gists, SnippetsLab export) is supported.
+- **Snippets only, or more?** If your day also includes notes, HTTP requests, and quick math, a workspace beats a single-purpose app.
+- **Free, one-time, or subscription?** Decide what you are willing to pay before you get attached.
+
+## Recommendations by use case
+
+- **You want plain files you own, on every platform, for free** — and notes plus HTTP and math in the same app: choose **massCode**.
+- **You are macOS-only and want a polished native app:** choose **SnippetsLab**.
+- **You want an AI copilot over your snippets:** choose **Pieces**.
+- **Your team needs a shared, hosted snippet library:** choose **Cacher**.
+- **You want your library to be GitHub Gists:** choose **Lepton** or **GitHub Gist** directly.
+- **You want system-wide text expansion:** choose **Raycast Snippets**.
+- **You only insert templated code inside VS Code:** the built-in **VS Code snippets** are enough.
+
+## Frequently asked questions
+
+### What is a code snippet manager?
+
+A code snippet manager is an app for saving, organizing, and quickly retrieving reusable pieces of code and text — regexes, config blocks, commands, queries, and boilerplate. Good ones add folders or tags, full-text search, syntax highlighting, and imports so your existing snippets come along.
+
+### What is the best free code snippet manager?
+
+For a free, cross-platform, open-source option, [massCode](/download/) stores every snippet as a plain Markdown file on your disk with no account required. Lepton (MIT) is also free but stores snippets as GitHub Gists. VS Code's built-in snippets are free for in-editor expansion.
+
+### What is the best open-source code snippet manager?
+
+The main open-source options are massCode (AGPL v3, local Markdown files, cross-platform) and Lepton (MIT, GitHub Gist-backed). For a deeper look at licenses and trade-offs, see [Best open-source snippet manager](/compare/best-open-source).
+
+### Where are my code snippets actually stored?
+
+It depends on the tool. massCode stores them as plain `.md` files on your local disk. SnippetsLab keeps a local library. Cacher and GitHub Gist store them in the cloud. Lepton stores them as GitHub Gists. If reading your snippets without the app matters to you, prefer a tool with documented local file storage.
+
+### Can I move my snippets between snippet managers?
+
+Often, yes. massCode imports VS Code snippets JSON, Raycast snippets JSON, SnippetsLab JSON, public GitHub Gist URLs, and Obsidian markdown folders, so migrating an existing library is usually a few clicks rather than a manual copy.
+
+## Try massCode
+
+If your answers point to local files, cross-platform, no account, free, open-source, and more than just snippets, massCode is the closest match. [Download massCode](/download/) or browse the [comparisons](/compare/) to see how it stacks up against the tool you use today.

--- a/docs/website/compare/best-code-snippet-managers.md
+++ b/docs/website/compare/best-code-snippet-managers.md
@@ -26,7 +26,7 @@ Star count and marketing aside, a snippet manager is worth adopting when it hand
 
 | Tool | License | Platforms | Storage | Account | Scope |
 | --- | --- | --- | --- | --- | --- |
-| [massCode](#masscode) | Open source (AGPL v3) | macOS, Windows, Linux | Local Markdown files | No | Snippets + notes, HTTP, math, tools |
+| [massCode](#masscode) | Open source (AGPL v3) | macOS, Windows, Linux | Local Markdown files | No | Snippets + notes, HTTP, math, drawings, tools |
 | [SnippetsLab](#snippetslab) | Proprietary | macOS only | Local library | No | Snippets |
 | [Pieces](#pieces) | Proprietary | macOS, Windows, Linux + IDE/browser | On-device / local | Optional | Snippets + AI companion |
 | [Cacher](#cacher) | Proprietary | macOS, Windows, Linux | Cloud | Yes | Snippets, team libraries |
@@ -41,7 +41,7 @@ Details and trade-offs for each are below.
 
 ### massCode
 
-[massCode](https://github.com/massCodeIO/massCode) is a free, open-source, local-first developer workspace. Snippets sit alongside notes, HTTP requests, math sheets, and dev tools, and everything is stored as plain Markdown files in a [Markdown Vault](/documentation/storage) on your own disk.
+[massCode](https://github.com/massCodeIO/massCode) is a free, open-source, local-first developer workspace. Snippets sit alongside notes, HTTP requests, math sheets, drawings, and dev tools, and everything is stored as plain Markdown files in a [Markdown Vault](/documentation/storage) on your own disk.
 
 - **License:** [AGPL v3](https://github.com/massCodeIO/massCode/blob/master/LICENSE), source on [GitHub](https://github.com/massCodeIO/massCode)
 - **Platforms:** macOS, Windows, Linux
@@ -51,7 +51,7 @@ Details and trade-offs for each are below.
 - **Imports:** VS Code snippets JSON, Raycast snippets JSON, SnippetsLab JSON, public GitHub Gist URLs, and Obsidian markdown folders
 - **Sync:** Bring your own — iCloud, Dropbox, Google Drive, Syncthing, or [Git](/documentation/sync)
 
-**Best for:** developers who want their snippets to stay as plain files they own, on every platform, for free, and who appreciate having notes, HTTP requests, and math in the same window. [Download massCode](/download/) to try it.
+**Best for:** developers who want their snippets to stay as plain files they own, on every platform, for free, and who appreciate having notes, HTTP requests, math, and drawings in the same window. [Download massCode](/download/) to try it.
 
 ### SnippetsLab
 
@@ -145,7 +145,7 @@ Work through these questions before installing anything:
 
 ## Recommendations by use case
 
-- **You want plain files you own, on every platform, for free** — and notes plus HTTP and math in the same app: choose **massCode**.
+- **You want plain files you own, on every platform, for free** — and notes, HTTP, math, and drawings in the same app: choose **massCode**.
 - **You are macOS-only and want a polished native app:** choose **SnippetsLab**.
 - **You want an AI copilot over your snippets:** choose **Pieces**.
 - **Your team needs a shared, hosted snippet library:** choose **Cacher**.

--- a/docs/website/compare/index.md
+++ b/docs/website/compare/index.md
@@ -26,6 +26,7 @@ This section helps you decide whether massCode fits your workflow, or whether an
 
 ## Category and positioning pages
 
+- [Best code snippet managers](/compare/best-code-snippet-managers) — the leading snippet managers compared on storage, license, platforms, price, and scope
 - [Best open-source snippet manager](/compare/best-open-source) — what to look for, and how the open-source options stack up
 - [Local-first alternative to Pieces and Cacher](/compare/local-first) — keeping snippets and notes on your own disk
 - [Markdown-first task manager for developers](/compare/markdown-first-tasks) — why tasks belong as plain `.md` files next to your notes and snippets


### PR DESCRIPTION
Adds a category comparison page `/compare/best-code-snippet-managers` targeting high-intent listicle queries ("best code snippet managers", "code snippet manager/tool/library", "snippet software").

- Honest listicle comparing massCode, SnippetsLab, Pieces, Cacher, Lepton, GitHub Gist, Raycast Snippets, and VS Code snippets on license, platforms, storage, account, and scope.
- At-a-glance table, per-tool breakdown, how-to-choose, by-use-case recommendations, and FAQ for SEO/AI snippets.
- All competitor facts verified against official sources at write time (SnippetsLab now free; Pieces on-device; Lepton flagged as unmaintained; Cacher active).
- Registered in the compare sidebar (`config.mts`) and `compare/index.md`.