### PR TITLE
docs: add massCode vs GitHub Gist comparison page

### DIFF
--- a/docs/website/.vitepress/config.mts
+++ b/docs/website/.vitepress/config.mts
@@ -104,6 +104,7 @@ export default defineConfig({
             { text: 'massCode vs Cacher', link: '/compare/cacher' },
             { text: 'massCode vs SnippetsLab', link: '/compare/snippetslab' },
             { text: 'massCode vs Raycast Snippets', link: '/compare/raycast' },
+            { text: 'massCode vs GitHub Gist', link: '/compare/github-gist' },
             { text: 'massCode vs Todoist', link: '/compare/todoist' },
             { text: 'massCode vs TickTick', link: '/compare/ticktick' },
             { text: 'massCode vs Things 3', link: '/compare/things' },

--- a/docs/website/compare/best-code-snippet-managers.md
+++ b/docs/website/compare/best-code-snippet-managers.md
@@ -108,7 +108,7 @@ Details and trade-offs for each are below.
 - **Storage:** Cloud (your GitHub account)
 - **Scope:** Snippets as Gists
 
-**Best for:** quick, shareable, public or secret snippets you already manage on GitHub. As a primary library it lacks folders, rich organization, and offline-first storage. If you outgrow it, massCode can [import your Gists](/documentation/code/library) by URL.
+**Best for:** quick, shareable, public or secret snippets you already manage on GitHub. As a primary library it lacks folders, rich organization, and offline-first storage. If you outgrow it, massCode can [import your Gists](/documentation/code/library) by URL — see [massCode vs GitHub Gist](/compare/github-gist).
 
 ### Raycast Snippets
 

--- a/docs/website/compare/github-gist.md
+++ b/docs/website/compare/github-gist.md
@@ -1,0 +1,100 @@
+---
+title: massCode vs GitHub Gist
+description: "An honest comparison between massCode and GitHub Gist as a snippet manager. Local-first Markdown workspace with folders and full-text search vs cloud-hosted Git-backed gists. When each one is the better choice, and how to import your Gists into massCode."
+---
+
+# massCode vs GitHub Gist
+
+[GitHub Gist](https://gist.github.com) is the snippet tool millions of developers already have, because they already have a GitHub account. It is free, instantly shareable, and every gist is a real Git repository. Many people use it as their de facto snippet manager.
+
+massCode is a free, open-source, local-first developer workspace where snippets, notes, HTTP requests, math, drawings, and dev tools live as plain Markdown files on your own disk.
+
+The two solve overlapping problems from opposite directions. Gist is a cloud service optimized for sharing individual snippets. massCode is a local library optimized for organizing and searching the snippets you keep. If you mainly share one-off snippets with other people, Gist is the natural fit. If you want a private, organized, searchable library you own, massCode is the natural fit. Many developers use both.
+
+## At a glance
+
+| | massCode | GitHub Gist |
+| --- | --- | --- |
+| Type | Desktop app / local library | Cloud service |
+| License | Open source (AGPL v3) | Proprietary service |
+| Pricing | Free | Free |
+| Data location | Local Markdown Vault on your disk | GitHub's servers |
+| Account required | No | Yes (GitHub account) |
+| Works offline | Yes | No (needs github.com) |
+| Organization | Folders, tags, fragments | None (a flat list of gists) |
+| Search | Full-text across snippets, notes, HTTP requests | Public gists only; secret gists searchable only by you when signed in |
+| Privacy | Files stay on your machine | Public, or "secret" (unlisted, not private) |
+| Version history | File-level (via your own Git/sync if you want it) | Built in — every gist is a Git repository |
+| Sharing | File-level (Git, shared folder) | A core strength — share or embed any gist by URL |
+| Scope | Snippets, notes, HTTP, math, drawings, tools | Snippets only |
+
+Sources: [GitHub Docs — Creating gists](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists).
+
+## What GitHub Gist is genuinely good at
+
+Gist earns its popularity. It is worth being clear about where it wins:
+
+- **Zero setup.** If you have a GitHub account, you already have Gist. Nothing to install.
+- **Sharing and embedding.** Paste a snippet, get a URL, send it or embed it in a blog post. This is the thing Gist does better than almost anything else.
+- **Real Git under the hood.** "Every gist is a Git repository, which means that it can be forked and cloned." You get full commit history and diffs for free.
+- **Collaboration.** Gists can be forked and commented on, which makes them good for quick public collaboration.
+
+If your main job is *publishing* snippets for other people to see, Gist is hard to beat.
+
+## Where Gist falls short as a snippet library
+
+The trouble starts when you try to use Gist as the place you *keep and organize* your own snippets:
+
+- **No folders, no tags.** Gists are a flat list. There is no built-in way to group them into folders or organize them with tags, so a growing library gets hard to navigate.
+- **Weak search.** Public gists are searchable, but "secret gists don't show up in Discover and are not searchable unless you are logged in and are the author." There is no fast full-text search across your whole library the way a dedicated app provides.
+- **"Secret" is not private.** GitHub is explicit: "Secret gists aren't private. If you send the URL of a secret gist to a friend, they'll be able to see it." Anyone who discovers the URL can read it. As of November 2025, GitHub also reports secrets found in unlisted gists to secret-scanning partners. For anything sensitive, a gist is the wrong place.
+- **Online only.** Gist needs github.com. There is no offline-first local copy you browse without a connection.
+- **Your data lives on someone else's server.** It is convenient, but it is not a local file you own and can read without the service.
+- **Snippets only.** Gist does not cover notes, HTTP requests, math, or the rest of a developer's day.
+
+## How massCode is different
+
+massCode is built to be the library, not the publishing channel:
+
+- **Local-first.** Every snippet and note is a plain `.md` file in a [Markdown Vault](/documentation/storage) on your disk. You can read, edit, and back it up without the app, and it works fully offline.
+- **Real organization.** [Folders](/documentation/code/folders), tags, and multi-tab [fragments](/documentation/fragments) for snippets that belong together.
+- **Full-text search** across snippets, notes, and HTTP requests, instantly and locally.
+- **Private by default.** Nothing leaves your machine unless you choose a sync service.
+- **More than snippets.** [Code](/documentation/code/library), [Notes](/documentation/notes/), [HTTP](/documentation/http/), [Math](/documentation/math/), [Drawings](/documentation/drawings/), and [Tools](/documentation/tools/) in one app.
+- **No account.** It works without registering for anything.
+
+The trade-off is honest: massCode does not give you Gist's one-click public sharing and embedding. If publishing snippets to the web is your main need, keep using Gist for that.
+
+## Migrating from GitHub Gist to massCode
+
+You do not have to choose blindly. massCode can import a public GitHub Gist directly by URL, so you can pull existing snippets into an organized, local library and try it without retyping anything. Paste the Gist URL into massCode's import flow and the snippet lands in your vault as a Markdown file you can then file into folders and tag. See [the Code library docs](/documentation/code/library) for import details.
+
+A common setup: keep massCode as your private, searchable library, and publish to Gist only the specific snippets you want to share.
+
+## When each one is the better choice
+
+- **Choose GitHub Gist** if your primary need is sharing or embedding individual snippets, you want zero setup, and you are comfortable with cloud storage tied to your GitHub account.
+- **Choose massCode** if you want a private, organized, searchable library of your own snippets, stored as plain files on your disk, that works offline and also handles notes, HTTP, and math.
+- **Use both** if, like many developers, you want a local library for everything and Gist for the handful of snippets you publish.
+
+## Frequently asked questions
+
+### Is GitHub Gist a good snippet manager?
+
+For *sharing* snippets, yes — it is excellent. For *organizing and searching your own growing library*, it is limited: there are no folders or tags, search is weak for your private gists, and it is online-only. Many developers outgrow Gist as a primary library and move to a dedicated app while still using Gist for sharing.
+
+### Are secret gists private?
+
+No. Per GitHub, "Secret gists aren't private" — they are unlisted, meaning anyone with the URL can view them. For anything sensitive, use a private repository or a local-first tool like massCode instead.
+
+### What is a good GitHub Gist alternative?
+
+If you want your snippets organized and searchable on your own disk, [massCode](/download/) is a free, open-source, local-first alternative that can import your existing public Gists by URL. For other options, see [Best code snippet managers](/compare/best-code-snippet-managers).
+
+### Can I import my GitHub Gists into massCode?
+
+Yes. massCode imports public GitHub Gist URLs, so you can bring existing snippets into a local, organized library. See [the Code library docs](/documentation/code/library).
+
+## Try massCode
+
+If you have been using Gist as a snippet library and feel the lack of folders, search, and privacy, a local-first workspace is the natural next step. [Download massCode](/download/) and import a Gist URL to see how it feels to own your library.

--- a/docs/website/compare/index.md
+++ b/docs/website/compare/index.md
@@ -15,6 +15,7 @@ This section helps you decide whether massCode fits your workflow, or whether an
 - [massCode vs Cacher](/compare/cacher) — open-source local app vs team-oriented cloud SaaS
 - [massCode vs SnippetsLab](/compare/snippetslab) — cross-platform vs macOS-only
 - [massCode vs Raycast Snippets](/compare/raycast) — full snippet workspace vs launcher text expansion
+- [massCode vs GitHub Gist](/compare/github-gist) — local-first organized library vs cloud Git-backed gists
 
 ## Task managers
 


### PR DESCRIPTION
Adds `/compare/github-gist` targeting the "github gist alternative" query (already ranking ~position 2 with no dedicated page).

- Honest comparison: Gist's strengths (zero setup, sharing/embedding, real Git) vs its limits as a library (no folders/tags, weak private search, "secret" gists are not private, online-only).
- Migration angle: massCode imports public Gist URLs.
- All Gist facts verified against GitHub Docs at write time (secret gists not private; every gist is a Git repo; no native folders/tags; Nov 2025 secret-scanning of unlisted gists).
- Cross-linked with the new `best-code-snippet-managers` hub; registered in compare sidebar and index.