### PR TITLE
docs: fix broken fragments link and clarify HTTP search scope

### DIFF
--- a/docs/website/compare/best-code-snippet-managers.md
+++ b/docs/website/compare/best-code-snippet-managers.md
@@ -47,7 +47,7 @@ Details and trade-offs for each are below.
 - **Platforms:** macOS, Windows, Linux
 - **Storage:** Local `.md` files you can read, edit, and back up without the app
 - **Account:** None required, no telemetry login
-- **Search:** Full-text across snippets, notes, and HTTP requests
+- **Search:** Full-text across snippets and notes (HTTP requests by name and URL)
 - **Imports:** VS Code snippets JSON, Raycast snippets JSON, SnippetsLab JSON, public GitHub Gist URLs, and Obsidian markdown folders
 - **Sync:** Bring your own — iCloud, Dropbox, Google Drive, Syncthing, or [Git](/documentation/sync)
 

--- a/docs/website/compare/github-gist.md
+++ b/docs/website/compare/github-gist.md
@@ -22,7 +22,7 @@ The two solve overlapping problems from opposite directions. Gist is a cloud ser
 | Account required | No | Yes (GitHub account) |
 | Works offline | Yes | No (needs github.com) |
 | Organization | Folders, tags, fragments | None (a flat list of gists) |
-| Search | Full-text across snippets, notes, HTTP requests | Public gists only; secret gists searchable only by you when signed in |
+| Search | Full-text across snippets and notes (HTTP by name and URL) | Public gists only; secret gists searchable only by you when signed in |
 | Privacy | Files stay on your machine | Public, or "secret" (unlisted, not private) |
 | Version history | File-level (via your own Git/sync if you want it) | Built in — every gist is a Git repository |
 | Sharing | File-level (Git, shared folder) | A core strength — share or embed any gist by URL |
@@ -57,8 +57,8 @@ The trouble starts when you try to use Gist as the place you *keep and organize*
 massCode is built to be the library, not the publishing channel:
 
 - **Local-first.** Every snippet and note is a plain `.md` file in a [Markdown Vault](/documentation/storage) on your disk. You can read, edit, and back it up without the app, and it works fully offline.
-- **Real organization.** [Folders](/documentation/code/folders), tags, and multi-tab [fragments](/documentation/fragments) for snippets that belong together.
-- **Full-text search** across snippets, notes, and HTTP requests, instantly and locally.
+- **Real organization.** [Folders](/documentation/code/folders), tags, and multi-tab [fragments](/documentation/code/fragments) for snippets that belong together.
+- **Full-text search** across snippets and notes (HTTP requests are searched by name and URL), instantly and locally.
 - **Private by default.** Nothing leaves your machine unless you choose a sync service.
 - **More than snippets.** [Code](/documentation/code/library), [Notes](/documentation/notes/), [HTTP](/documentation/http/), [Math](/documentation/math/), [Drawings](/documentation/drawings/), and [Tools](/documentation/tools/) in one app.
 - **No account.** It works without registering for anything.


### PR DESCRIPTION
Accuracy fixes from an audit of the snippet comparison pages against the actual app and source.

- Fix broken internal link `/documentation/fragments` → `/documentation/code/fragments` on the GitHub Gist page (the doc lives under `code/`).
- Correct the search claim on both the hub and Gist pages: massCode list search is full-text for snippets (name + description + all fragment contents) and notes (name + content), but HTTP requests are matched by name and URL only (verified in `src/main/.../http/storages/requests.ts`). Previous wording overstated full-text across HTTP.