### PR TITLE
docs: add per-platform snippet manager pages for Mac and Windows

### DIFF
--- a/docs/website/.vitepress/config.mts
+++ b/docs/website/.vitepress/config.mts
@@ -121,6 +121,8 @@ export default defineConfig({
             { text: 'massCode vs Apple Reminders', link: '/compare/apple-reminders' },
             { text: 'massCode vs Obsidian Tasks', link: '/compare/obsidian-tasks' },
             { text: 'Best Code Snippet Managers', link: '/compare/best-code-snippet-managers' },
+            { text: 'Code Snippet Manager for Mac', link: '/compare/code-snippet-manager-for-mac' },
+            { text: 'Code Snippet Manager for Windows', link: '/compare/code-snippet-manager-for-windows' },
             { text: 'Best Open-Source Snippet Manager', link: '/compare/best-open-source' },
             { text: 'Local-First Alternative to Pieces / Cacher', link: '/compare/local-first' },
             { text: 'Markdown-First Task Manager', link: '/compare/markdown-first-tasks' },

--- a/docs/website/compare/code-snippet-manager-for-mac.md
+++ b/docs/website/compare/code-snippet-manager-for-mac.md
@@ -1,0 +1,58 @@
+---
+title: Code Snippet Manager for Mac
+description: "What to look for in a code snippet manager on macOS, and why massCode is a strong choice — a free, open-source, local-first app that stores snippets as plain Markdown files and follows you to Windows and Linux too."
+---
+
+# Code Snippet Manager for Mac
+
+macOS has more good snippet managers than any other platform, which is both a blessing and a trap. Some are macOS-only and beautiful; some are cross-platform and practical. The right pick depends on whether you live entirely on a Mac or move between machines — and on whether you want your snippets locked to one app or kept as files you own.
+
+This page covers what matters in a snippet manager on the Mac, and where [massCode](/download/) fits.
+
+## What to look for on macOS
+
+- **Native, not a web tab.** A real Mac app with proper keyboard shortcuts and a menu-bar presence beats a browser tab you forget to open.
+- **Local storage you own.** Snippets should live as files on your disk, readable without the app, not trapped in a database or a cloud account.
+- **Fast search and real organization.** Folders, tags, and full-text search are what turn a pile of snippets into a library.
+- **Mac-only or cross-platform?** A macOS-only app can feel more native, but if you ever touch a Windows or Linux machine, your library cannot follow. Decide this before you commit.
+- **No mandatory account.** It should work offline, immediately, without signing in.
+
+## massCode on macOS
+
+[massCode](https://github.com/massCodeIO/massCode) is a free, open-source, local-first developer workspace that runs natively on macOS (Apple Silicon and Intel), and also on Windows and Linux — so your library is never tied to one operating system.
+
+- **Local Markdown Vault.** Every snippet and note is a plain `.md` file with frontmatter on your disk. Read, edit, and back it up with any tool. See [Storage](/documentation/storage).
+- **Real organization.** Nested [folders](/documentation/code/folders), multiple [tags](/documentation/code/tags) per snippet, and [fragments](/documentation/code/fragments) — tabs inside one snippet for several languages or versions.
+- **Full-text search** across snippet names, descriptions, and the contents of every fragment, plus your notes.
+- **Keyboard-first.** Open the [Command Palette](/documentation/command-palette) with <kbd>Cmd+P</kbd> to jump to any snippet, or scope with `@code`, a `#tag`, or a `/folder`.
+- **Plays well with the Mac.** massCode ships a [Raycast extension](https://www.raycast.com/antonreshetov/masscode), so you can search your massCode snippets straight from Raycast.
+- **Yours to keep.** [AGPL v3](https://github.com/massCodeIO/massCode/blob/master/LICENSE), no account, no telemetry login. Sync the vault yourself with iCloud, Dropbox, or [any service you trust](/documentation/sync).
+- **Easy to adopt.** Import from VS Code snippets, Raycast snippets, SnippetsLab, public GitHub Gists, and Obsidian.
+
+## Other macOS options
+
+The Mac has strong alternatives, and the honest answer is that some fit certain workflows better:
+
+- **SnippetsLab** — a polished, macOS-only native app, free as of 2026. Great if you never leave the Apple ecosystem. See [massCode vs SnippetsLab](/compare/snippetslab).
+- **Raycast Snippets** — best as a system-wide text expander from the Raycast launcher, rather than a long-form library. See [massCode vs Raycast Snippets](/compare/raycast).
+- **Pieces** — an AI-first option if you want a copilot over your snippets. See [massCode vs Pieces](/compare/pieces).
+
+For the full side-by-side, see [Best code snippet managers](/compare/best-code-snippet-managers).
+
+## Frequently asked questions
+
+### What is the best code snippet manager for Mac?
+
+It depends on whether you stay on macOS. If you want a polished macOS-only app, SnippetsLab is a strong, free choice. If you want a free, local-first library that also works on Windows and Linux and stores snippets as plain files you own, [massCode](/download/) is the better fit.
+
+### Is there a free snippet manager for Mac?
+
+Yes. massCode is free and open source, and SnippetsLab is free as of 2026. massCode additionally keeps your data as plain Markdown files and runs on Windows and Linux too.
+
+### Do I have to choose a macOS-only app?
+
+No, and it is worth thinking twice before you do. A macOS-only app cannot follow you to another OS. A cross-platform, local-first tool like massCode keeps the same library available everywhere and stored as files you control.
+
+## Try massCode on your Mac
+
+[Download massCode](/download/) for macOS — it is free, open source, and stores your snippets as plain files you own, on the Mac and everywhere else you work.

--- a/docs/website/compare/code-snippet-manager-for-windows.md
+++ b/docs/website/compare/code-snippet-manager-for-windows.md
@@ -1,0 +1,58 @@
+---
+title: Code Snippet Manager for Windows
+description: "What to look for in a code snippet manager on Windows, and why massCode is a strong choice — a free, open-source, local-first app that stores snippets as plain Markdown files and runs natively on Windows, macOS, and Linux."
+---
+
+# Code Snippet Manager for Windows
+
+Windows developers get a shorter list of good snippet managers than Mac users do. Several of the most polished apps — SnippetsLab, for example — are macOS-only, so a lot of "best snippet manager" advice simply does not apply on Windows. The good news: the strongest local-first options are cross-platform, and they run natively on Windows.
+
+This page covers what to look for on Windows and where [massCode](/download/) fits.
+
+## What to look for on Windows
+
+- **Actually runs on Windows.** Check first — many recommendations are Mac-only. You want a native Windows build, not a workaround.
+- **Local storage you own.** Snippets should be files on your disk, readable without the app, not locked in a database or a cloud account.
+- **Fast search and real organization.** Folders, tags, and full-text search are what make a snippet library usable as it grows.
+- **No mandatory account.** It should work offline and immediately, without signing in.
+- **Cross-platform, ideally.** If you ever use a Mac or Linux box, a tool that runs everywhere keeps one library instead of several.
+
+## massCode on Windows
+
+[massCode](https://github.com/massCodeIO/massCode) is a free, open-source, local-first developer workspace with a native Windows build (and macOS and Linux too). It is one of the few local-first snippet managers that treats Windows as a first-class platform.
+
+- **Local Markdown Vault.** Every snippet and note is a plain `.md` file with frontmatter on your disk. Read, edit, and back it up with any tool. See [Storage](/documentation/storage).
+- **Real organization.** Nested [folders](/documentation/code/folders), multiple [tags](/documentation/code/tags) per snippet, and [fragments](/documentation/code/fragments) — tabs inside one snippet for several languages or versions.
+- **Full-text search** across snippet names, descriptions, and the contents of every fragment, plus your notes.
+- **Keyboard-first.** Open the [Command Palette](/documentation/command-palette) with <kbd>Ctrl+P</kbd> to jump to any snippet, or scope with `@code`, a `#tag`, or a `/folder`.
+- **Yours to keep.** [AGPL v3](https://github.com/massCodeIO/massCode/blob/master/LICENSE), no account, no telemetry login. Sync the vault yourself with OneDrive, Dropbox, Google Drive, or [any service you trust](/documentation/sync).
+- **Easy to adopt.** Import from VS Code snippets, Raycast snippets, SnippetsLab, public GitHub Gists, and Obsidian.
+
+## Other Windows options
+
+The field is narrower than on macOS, but you do have choices:
+
+- **Pieces** — cross-platform and AI-first, if you want a copilot over your snippets. See [massCode vs Pieces](/compare/pieces).
+- **Cacher** — cross-platform and cloud-based, good for hosted team libraries if you are comfortable with an account. See [massCode vs Cacher](/compare/cacher).
+- **VS Code snippets** — built into the editor and available on Windows, fine for templated code you insert by prefix, but not a searchable library.
+- **SnippetsLab** — frequently recommended, but **macOS-only**, so it is not an option on Windows.
+
+For the full side-by-side, see [Best code snippet managers](/compare/best-code-snippet-managers).
+
+## Frequently asked questions
+
+### What is the best code snippet manager for Windows?
+
+For a free, local-first library that stores snippets as plain files you own and runs natively on Windows (and macOS and Linux), [massCode](/download/) is a strong choice. If you want AI features, Pieces is cross-platform; for a hosted team library, Cacher works on Windows.
+
+### Is there a free snippet manager for Windows?
+
+Yes. massCode is free and open source, runs natively on Windows, and stores your data as plain Markdown files on your disk. VS Code's built-in snippets are also free for in-editor use.
+
+### Why are so many snippet managers Mac-only?
+
+Several popular ones (such as SnippetsLab) are built specifically for the Apple ecosystem. That is why Windows developers should check platform support first and lean toward cross-platform, local-first tools that treat Windows as a first-class target.
+
+## Try massCode on Windows
+
+[Download massCode](/download/) for Windows — it is free, open source, and stores your snippets as plain files you own, on Windows and everywhere else you work.

--- a/docs/website/compare/index.md
+++ b/docs/website/compare/index.md
@@ -28,6 +28,8 @@ This section helps you decide whether massCode fits your workflow, or whether an
 ## Category and positioning pages
 
 - [Best code snippet managers](/compare/best-code-snippet-managers) — the leading snippet managers compared on storage, license, platforms, price, and scope
+- [Code snippet manager for Mac](/compare/code-snippet-manager-for-mac) — what to look for on macOS, and how massCode fits
+- [Code snippet manager for Windows](/compare/code-snippet-manager-for-windows) — the best local-first options on Windows
 - [Best open-source snippet manager](/compare/best-open-source) — what to look for, and how the open-source options stack up
 - [Local-first alternative to Pieces and Cacher](/compare/local-first) — keeping snippets and notes on your own disk
 - [Markdown-first task manager for developers](/compare/markdown-first-tasks) — why tasks belong as plain `.md` files next to your notes and snippets


### PR DESCRIPTION
Adds two persona pages targeting platform-qualified queries with real GSC demand:

- `/compare/code-snippet-manager-for-mac` — "code snippet manager for mac", "mac code snippet manager" (~228 impressions, position ~11).
- `/compare/code-snippet-manager-for-windows` — "snippets app for windows", "windows snippet manager" (~227 impressions, position ~12; "windows snippet manager" alone ~971 impressions).

Both are grounded in real massCode capabilities (Markdown Vault, folders/tags/fragments, full-text search across snippets and notes, Command Palette, imports, no account) and accurate competitor platform facts (SnippetsLab is macOS-only; Pieces/Cacher cross-platform). Cross-linked to the hub and registered in the compare sidebar and index.