### PR TITLE
docs: add FAQ sections to SnippetsLab, Pieces, and Cacher compare pages

### DIFF
--- a/docs/website/compare/cacher.md
+++ b/docs/website/compare/cacher.md
@@ -72,3 +72,21 @@ To move from Cacher to massCode at the file level:
 4. If you previously relied on Cacher for team sharing, point your massCode vault at a shared Git repository so teammates can pull and push changes.
 
 [Download massCode](/download/) and try it on a copy of your snippets first.
+
+## Frequently asked questions
+
+### Is massCode a good Cacher alternative?
+
+Yes, if you prefer local-first over cloud. Cacher is a hosted, account-based service with team libraries. massCode is a free, open-source app that keeps your snippets as plain Markdown files on your own disk, working fully offline with no account.
+
+### Can I use massCode in a team like Cacher?
+
+Sharing in massCode happens at the file level: point your [Markdown Vault](/documentation/storage) at a shared Git repository or cloud folder so teammates can pull and push. That suits small teams, but it is not a managed, role-based team workspace like Cacher's.
+
+### Can I import my Cacher snippets into massCode?
+
+There is no direct Cacher importer. The practical path is to export snippets through GitHub Gists and import the public Gist URLs in [Code](/documentation/code/library), then adjust folders, tags, and languages.
+
+### Is massCode free?
+
+Yes, massCode is free and open source under AGPL v3. Cacher is a commercial cloud service, so the cost and hosting model are the main differences to weigh.

--- a/docs/website/compare/pieces.md
+++ b/docs/website/compare/pieces.md
@@ -72,3 +72,21 @@ If you want to consolidate into massCode:
 4. Move longer pieces of context into [Notes](/documentation/notes/) and link between them.
 
 [Download massCode](/download/) and try it on a copy of your data.
+
+## Frequently asked questions
+
+### Is massCode a good Pieces alternative?
+
+Yes, if you want a focused, local-first workspace rather than an AI copilot. Pieces is built around AI and long-term memory of your work. massCode is a free, open-source app that stores snippets, notes, HTTP requests, and math as plain Markdown files on your disk, with no AI layer in the way.
+
+### Does massCode have AI features?
+
+No. massCode has no built-in AI. It is a deliberately focused workspace for keeping and finding your own snippets and notes. If an AI copilot over your snippets is what you want, Pieces is the better fit.
+
+### Can I import my Pieces snippets into massCode?
+
+There is no direct Pieces importer. The practical path is to export snippets into a format massCode reads — for example, public GitHub Gist URLs — and import those, or recreate the rest manually under [Code](/documentation/code/library). massCode also imports VS Code, Raycast, and SnippetsLab snippets.
+
+### Is my data local with massCode?
+
+Yes. Every snippet and note is a plain `.md` file in a local [Markdown Vault](/documentation/storage), with no account required. You choose whether and how to sync it.

--- a/docs/website/compare/snippetslab.md
+++ b/docs/website/compare/snippetslab.md
@@ -72,3 +72,21 @@ To move from SnippetsLab to massCode:
 4. Move longer documentation into [Notes](/documentation/notes/) and link between notes and snippets.
 
 [Download massCode](/download/) and run it alongside SnippetsLab while you migrate.
+
+## Frequently asked questions
+
+### Is massCode a good SnippetsLab alternative?
+
+Yes, especially if you are not macOS-only. SnippetsLab is a polished, native, macOS-only app. massCode is a free, open-source, local-first workspace that runs on macOS, Windows, and Linux and stores snippets as plain Markdown files you own.
+
+### Can I import my SnippetsLab snippets into massCode?
+
+Yes. Export your library from SnippetsLab as JSON, then import it in massCode's [Code](/documentation/code/library) space. The import brings over snippets, folders, tags, descriptions, and fragments, with a preview before anything is written to your vault.
+
+### Is SnippetsLab or massCode better on Mac?
+
+If you only ever use a Mac and want the most native feel with automatic language detection and iCloud sync, SnippetsLab is excellent. If you want the same library on Windows or Linux too, or a single workspace that also covers notes, HTTP, and math, choose massCode. See also [Code snippet manager for Mac](/compare/code-snippet-manager-for-mac).
+
+### Is massCode free like SnippetsLab?
+
+Both are free. massCode is additionally open source under AGPL v3, and keeps your data as plain files rather than inside the app.


### PR DESCRIPTION
Deepens three thinner compare pages by adding an FAQ section to each (for SEO and AI-answer surfaces), matching the newer hub and persona pages.

- All answers grounded in real, verified facts: SnippetsLab JSON import really brings over folders/tags/descriptions/fragments; massCode has no built-in AI (honest on the Pieces page); no direct Pieces/Cacher importer (migration via Gist export); file-level team sharing via shared Git, not a managed team product.
- massCode VS Code extension referenced by these pages verified as real (Marketplace, AntonReshetov.masscode-assistant).
- Cross-links to the new Mac persona page and storage/library docs.