### PR TITLE
docs: add massCode vs Postman comparison page

### DIFF
--- a/docs/website/.vitepress/config.mts
+++ b/docs/website/.vitepress/config.mts
@@ -115,6 +115,7 @@ export default defineConfig({
             { text: 'massCode vs SnippetsLab', link: '/compare/snippetslab' },
             { text: 'massCode vs Raycast Snippets', link: '/compare/raycast' },
             { text: 'massCode vs GitHub Gist', link: '/compare/github-gist' },
+            { text: 'massCode vs Postman', link: '/compare/postman' },
             { text: 'massCode vs Todoist', link: '/compare/todoist' },
             { text: 'massCode vs TickTick', link: '/compare/ticktick' },
             { text: 'massCode vs Things 3', link: '/compare/things' },

--- a/docs/website/compare/index.md
+++ b/docs/website/compare/index.md
@@ -16,6 +16,7 @@ This section helps you decide whether massCode fits your workflow, or whether an
 - [massCode vs SnippetsLab](/compare/snippetslab) — cross-platform vs macOS-only
 - [massCode vs Raycast Snippets](/compare/raycast) — full snippet workspace vs launcher text expansion
 - [massCode vs GitHub Gist](/compare/github-gist) — local-first organized library vs cloud Git-backed gists
+- [massCode vs Postman](/compare/postman) — lightweight local-first API client vs full cloud API platform
 
 ## Task managers
 

--- a/docs/website/compare/postman.md
+++ b/docs/website/compare/postman.md
@@ -21,7 +21,7 @@ If you need an end-to-end API platform for a team, Postman is the more capable t
 | Works offline | Yes, fully | Lightweight client works offline; synced workspaces need the cloud |
 | Platforms | macOS, Windows, Linux | macOS, Windows, Linux, web, CLI |
 | Request features | Method, URL, params, headers, body, auth, markdown description | Full request editor with extensive auth and protocol support |
-| Environments | Yes, `{{variables}}` | Yes, with broader scoping |
+| Environments | Yes, <code v-pre>{{variables}}</code> | Yes, with broader scoping |
 | Protocols | HTTP | HTTP, WebSocket, gRPC, GraphQL, and more |
 | Mock servers / monitors / collection runner | No | Yes |
 | Automated tests / scripting | No | Yes (JavaScript test scripts, Newman/CLI) |
@@ -50,7 +50,7 @@ massCode is not trying to be a platform. It is trying to be the fast, local plac
 - **No account.** Open the app and send a request — nothing to sign into.
 - **Free and open source.** [AGPL v3](https://github.com/massCodeIO/massCode/blob/master/LICENSE), with no per-seat pricing or free-tier caps.
 - **Next to everything else.** Requests sit beside your [snippets](/documentation/code/library), [notes](/documentation/notes/), and [math](/documentation/math/), so API work stays in the same window as the rest of your day.
-- **The essentials, done simply.** Method, URL, params, headers, body, auth, a markdown description per request, [environments](/documentation/http/environments) with `{{variables}}`, response preview, and copy as raw HTTP or cURL.
+- **The essentials, done simply.** Method, URL, params, headers, body, auth, a markdown description per request, [environments](/documentation/http/environments) with <code v-pre>{{variables}}</code>, response preview, and copy as raw HTTP or cURL.
 - **Almost nothing to relearn.** Postman has grown into a large platform, and developers who just want to send a request — especially when they come back to it after months away — often have to re-find their way around the interface. massCode's HTTP space is a short, flat set of panels. There is no platform to navigate, so picking it back up after a break takes seconds, not a tour.
 
 If you mainly save requests by project and fire them during development, this is less to manage than a full platform.

--- a/docs/website/compare/postman.md
+++ b/docs/website/compare/postman.md
@@ -51,6 +51,7 @@ massCode is not trying to be a platform. It is trying to be the fast, local plac
 - **Free and open source.** [AGPL v3](https://github.com/massCodeIO/massCode/blob/master/LICENSE), with no per-seat pricing or free-tier caps.
 - **Next to everything else.** Requests sit beside your [snippets](/documentation/code/library), [notes](/documentation/notes/), and [math](/documentation/math/), so API work stays in the same window as the rest of your day.
 - **The essentials, done simply.** Method, URL, params, headers, body, auth, a markdown description per request, [environments](/documentation/http/environments) with `{{variables}}`, response preview, and copy as raw HTTP or cURL.
+- **Almost nothing to relearn.** Postman has grown into a large platform, and developers who just want to send a request — especially when they come back to it after months away — often have to re-find their way around the interface. massCode's HTTP space is a short, flat set of panels. There is no platform to navigate, so picking it back up after a break takes seconds, not a tour.
 
 If you mainly save requests by project and fire them during development, this is less to manage than a full platform.
 
@@ -83,6 +84,10 @@ See [Importing HTTP Collections](/documentation/http/importing) for the full wor
 ### Is massCode a good Postman alternative?
 
 For lightweight, local API work, yes. massCode is a free, open-source, local-first client that saves requests as plain files with no account. It is not a replacement for Postman's platform features — automated testing, mock servers, multiple protocols, and team governance — so it suits individual development more than large-scale API testing.
+
+### Is Postman too complicated for simple API testing?
+
+Postman is a full API platform, so its interface carries a lot of surface area — workspaces, collections, environments, mocks, monitors, runners, and more. If you only need to save and send a few requests, that breadth can feel like a lot to navigate, and returning users often have to reorient themselves. massCode's HTTP client is deliberately minimal, which makes it quicker for that narrower job. For heavy testing and automation, Postman's depth is the point.
 
 ### Does massCode need an account like Postman?
 

--- a/docs/website/compare/postman.md
+++ b/docs/website/compare/postman.md
@@ -1,0 +1,105 @@
+---
+title: massCode vs Postman
+description: "An honest comparison between massCode and Postman. A full cloud-first API platform vs a lightweight, local-first API client that stores requests as plain files on your disk — and can import your Postman collections."
+---
+
+# massCode vs Postman
+
+[Postman](https://www.postman.com) and massCode both let you build and send HTTP requests, but they are not the same kind of tool. Postman is a full API development platform — collections, environments, mock servers, monitors, automated test runs, and team collaboration, built around a cloud account. massCode is a free, open-source developer workspace whose [HTTP space](/documentation/http/) is a lightweight, local-first API client that lives next to your snippets and notes and stores everything as plain files on your disk.
+
+If you need an end-to-end API platform for a team, Postman is the more capable tool. If you want a fast, local API client for saving and sending requests during development — with no account and your data as files you own — massCode is the more natural fit. And because massCode imports Postman collections, you do not have to start over.
+
+## At a glance
+
+| | massCode | Postman |
+| --- | --- | --- |
+| Category | Local-first developer workspace with an HTTP client | Full cloud-first API platform |
+| License | Open source (AGPL v3) | Proprietary |
+| Pricing | Free | Free tier (limited); paid plans from ~$14/user/mo (2026) |
+| Data location | Local Markdown Vault on your disk | Cloud workspace; local-only via the lightweight client |
+| Account | Not required | Optional — full features and sync need an account; a no-sign-in lightweight client exists |
+| Works offline | Yes, fully | Lightweight client works offline; synced workspaces need the cloud |
+| Platforms | macOS, Windows, Linux | macOS, Windows, Linux, web, CLI |
+| Request features | Method, URL, params, headers, body, auth, markdown description | Full request editor with extensive auth and protocol support |
+| Environments | Yes, `{{variables}}` | Yes, with broader scoping |
+| Protocols | HTTP | HTTP, WebSocket, gRPC, GraphQL, and more |
+| Mock servers / monitors / collection runner | No | Yes |
+| Automated tests / scripting | No | Yes (JavaScript test scripts, Newman/CLI) |
+| Team collaboration | File-level (shared Git or folder) | Built-in shared workspaces and governance |
+| Imports | OpenAPI, Postman Collection v2.1, Postman Environment, Bruno | Postman formats, OpenAPI, and more |
+| Other workspaces | Snippets, notes, math, drawings, tools | API-focused |
+
+Pricing and plan limits per [Postman pricing](https://www.postman.com/pricing/); account and offline behavior per [Postman docs](https://learning.postman.com/docs/getting-started/basics/using-api-client/).
+
+## Where Postman fits better
+
+Postman is a platform, and for platform work it is hard to match:
+
+- **Automated testing and CI.** JavaScript test scripts, the collection runner, and the Newman CLI let you run API tests in pipelines.
+- **More protocols.** Beyond HTTP, Postman handles WebSocket, gRPC, and GraphQL in one place.
+- **Mock servers and monitors.** Stand up mock endpoints and schedule uptime/behavior checks.
+- **Team collaboration and governance.** Shared workspaces, role-based access, and API governance for organizations.
+
+If your work is API design, testing, and collaboration at team scale, Postman is built for exactly that.
+
+## Where massCode fits better
+
+massCode is not trying to be a platform. It is trying to be the fast, local place your requests live:
+
+- **Local-first, plain files.** Every request is stored in your [Markdown Vault](/documentation/storage) on disk, readable and Git-friendly, with no cloud dependency.
+- **No account.** Open the app and send a request — nothing to sign into.
+- **Free and open source.** [AGPL v3](https://github.com/massCodeIO/massCode/blob/master/LICENSE), with no per-seat pricing or free-tier caps.
+- **Next to everything else.** Requests sit beside your [snippets](/documentation/code/library), [notes](/documentation/notes/), and [math](/documentation/math/), so API work stays in the same window as the rest of your day.
+- **The essentials, done simply.** Method, URL, params, headers, body, auth, a markdown description per request, [environments](/documentation/http/environments) with `{{variables}}`, response preview, and copy as raw HTTP or cURL.
+
+If you mainly save requests by project and fire them during development, this is less to manage than a full platform.
+
+## Honest trade-offs
+
+- **massCode is a lightweight client, not a platform.** No mock servers, monitors, collection runner, or scripted tests. If you need those, Postman wins.
+- **HTTP only.** massCode's client handles HTTP requests; it does not cover WebSocket, gRPC, or GraphQL.
+- **Plain-text storage.** Requests live as plain files, so do not store real passwords, tokens, or keys in requests or environments if your vault is synced, shared, or committed to Git. Use an external secret manager.
+- **Newer and smaller.** The HTTP space arrived in massCode 5.3 and is intentionally focused, not feature-complete against a decade-old platform.
+
+## Who should pick which
+
+- Pick **Postman** if you need automated API testing, mock servers, multiple protocols, or managed team collaboration and governance.
+- Pick **massCode** if you want a free, local-first API client for saving and sending requests, stored as plain files with no account, inside a workspace that also holds your snippets and notes.
+- **Use both** if it suits you: Postman for heavy testing and team work, massCode as the quick local client next to your code.
+
+## Migrating from Postman to massCode
+
+You can bring your existing Postman work into massCode:
+
+1. In Postman, export a collection as **Collection v2.1 (JSON)**, and export your environment as JSON.
+2. In massCode, open the [HTTP](/documentation/http/) space and choose import.
+3. Select the exported Postman Collection and Environment files. massCode shows a preview with item counts, folders, and warnings for anything that has no equivalent (such as unsupported auth or scripts).
+4. Import to write the requests into your Markdown Vault, then organize them into folders.
+
+See [Importing HTTP Collections](/documentation/http/importing) for the full workflow. [Download massCode](/download/) and try importing a collection on a copy first.
+
+## Frequently asked questions
+
+### Is massCode a good Postman alternative?
+
+For lightweight, local API work, yes. massCode is a free, open-source, local-first client that saves requests as plain files with no account. It is not a replacement for Postman's platform features — automated testing, mock servers, multiple protocols, and team governance — so it suits individual development more than large-scale API testing.
+
+### Does massCode need an account like Postman?
+
+massCode never requires an account; your data stays in local files. Postman can be used without signing in through its lightweight API client, but full features and sync are tied to a Postman account.
+
+### Can I import my Postman collections into massCode?
+
+Yes. massCode imports Postman Collection v2.1 JSON and Postman Environment JSON, with a preview before anything is written to your vault. See [Importing HTTP Collections](/documentation/http/importing).
+
+### Does massCode support automated API testing?
+
+No. massCode's HTTP client is for building and sending requests and saving them by project. It does not include scripted tests, a collection runner, or monitors. If you need those, use Postman or a dedicated testing tool.
+
+### Is massCode free?
+
+Yes, massCode is free and open source under AGPL v3, with no per-seat pricing. As of 2026, Postman's free plan is limited to a single user with a monthly cap on collection runs, and team features require a paid plan.
+
+## Try massCode
+
+If you want a local-first API client that stores requests as plain files you own — and keeps them next to your snippets and notes — [download massCode](/download/) and import a Postman collection to see how it feels.


### PR DESCRIPTION
Adds `/compare/postman` — the seed page for the HTTP/API territory (Track B).

Honest framing: Postman is a full cloud-first API platform; massCode's HTTP space is a lightweight, local-first API client inside a workspace. No outdated "Postman forces login" angle — verified that since May 2023 Postman offers a no-sign-in lightweight client (Scratch Pad deprecated). Differentiators are local-first plain files, no account, free/open-source, all-in-one, and the 2026 free-tier tightening.

- All Postman facts verified from Postman docs/pricing at write time (lightweight client + offline behavior; 2026 free plan = 1 user, capped collection runs; paid from ~$14/user/mo).
- Strong migration story grounded in the real importer: massCode imports Postman Collection v2.1 + Environment JSON (per `imports.md`).
- massCode HTTP capabilities grounded in the docs (requests, environments, copy as cURL); honest trade-offs (no mocks/monitors/runner/scripts, HTTP-only, plain-text storage warning).
- Registered in compare sidebar and index.

Note: the first-person flagship post "Why I built my own HTTP client" is intentionally NOT included — it needs the author's real motivations/voice rather than invented narrative.