### PR TITLE
ci(win): pin release build to windows-2022

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,11 @@ jobs:
           # затирали latest-mac.yml друг друга, ломая автообновление.
           - os: macos-15
             platform: mac
-          - os: windows-latest
+          # Закреплено на windows-2022 (VS 2022): на windows-latest приехал
+          # VS 2026 (v18), который приколоченный форк @electron/node-gyp не
+          # распознаёт ("version undefined") и падает при rebuild нативных
+          # модулей. Снять после апдейта electron-rebuild/node-gyp.
+          - os: windows-2022
             platform: win
           - os: ubuntu-latest
             platform: linux


### PR DESCRIPTION
Windows-джоба релиза падала на `electron-rebuild`: на образе `windows-latest` приехал Visual Studio 2026 (v18), который приколоченный форк `@electron/node-gyp` не распознаёт (`version undefined`) + баг `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` в PowerShell-поиске VS. Код не менялся — поломка пришла с обновлением образа раннера.

Закрепляем Windows-сборку на `windows-2022` (VS 2022), который текущий toolchain понимает. Снять после апдейта electron-rebuild/node-gyp.