### PR TITLE
feat(storage): show pending http requests and teach doctor index consistency

### DIFF
--- a/src/main/api/dto/http-requests.ts
+++ b/src/main/api/dto/http-requests.ts
@@ -91,6 +91,7 @@ const httpRequestItem = t.Object({
   filePath: t.String(),
   isFavorites: t.Number(),
   isDeleted: t.Number(),
+  pendingCloudDownload: t.Optional(t.Boolean()),
   createdAt: t.Number(),
   updatedAt: t.Number(),
 })
@@ -112,6 +113,7 @@ const httpRequestListItem = t.Object({
   filePath: t.String(),
   isFavorites: t.Number(),
   isDeleted: t.Number(),
+  pendingCloudDownload: t.Optional(t.Boolean()),
   createdAt: t.Number(),
   updatedAt: t.Number(),
 })

--- a/src/main/storage/providers/markdown/__tests__/doctor.test.ts
+++ b/src/main/storage/providers/markdown/__tests__/doctor.test.ts
@@ -109,6 +109,53 @@ afterEach(() => {
 })
 
 describe('vault doctor', () => {
+  it('reports files missing from the state index as pending registrations', () => {
+    // Файл с валидным frontmatter-id, но не зарегистрированный в state:
+    // приложение его не отображает, doctor обязан это показать.
+    writeFile('code/Orphan.md', snippetSource(5, 'Orphan'))
+
+    const result = previewVaultDoctor({ spaces: ['code'] })
+
+    const item = result.items.find(
+      candidate =>
+        candidate.action === 'register-file' && candidate.path === 'Orphan.md',
+    )
+    expect(item?.status).toBe('pending')
+  })
+
+  it('registers unindexed files on apply', () => {
+    writeFile('code/Orphan.md', snippetSource(5, 'Orphan'))
+
+    applyVaultDoctor({ spaces: ['code'] })
+
+    const preview = previewVaultDoctor({ spaces: ['code'] })
+    expect(
+      preview.items.filter(item => item.action === 'register-file'),
+    ).toHaveLength(0)
+  })
+
+  it('warns about notes with folderId pointing to a missing folder', () => {
+    writeFile('notes/Projects/.meta.yaml', 'id: 3\nname: Projects\n')
+    writeFile(
+      'notes/Dangling.md',
+      ['---', 'id: 1', 'name: Dangling', 'folderId: 99', '---', 'body'].join(
+        '\n',
+      ),
+    )
+    writeFile(
+      'notes/Linked.md',
+      ['---', 'id: 2', 'name: Linked', 'folderId: 3', '---', 'body'].join('\n'),
+    )
+
+    const result = previewVaultDoctor({ spaces: ['notes'] })
+
+    const danglingWarnings = result.warnings.filter(
+      warning => warning.code === 'DANGLING_FOLDER_ID',
+    )
+    expect(danglingWarnings).toHaveLength(1)
+    expect(danglingWarnings[0].path).toBe('Dangling.md')
+  })
+
   it('reports duplicate code snippet ids as conflicts that need a decision', () => {
     writeFile('code/One.md', snippetSource(10, 'One'))
     writeFile('code/Two.md', snippetSource(10, 'Two'))

--- a/src/main/storage/providers/markdown/doctor.ts
+++ b/src/main/storage/providers/markdown/doctor.ts
@@ -59,6 +59,9 @@ interface ScanContext {
 interface EntityScanRecord {
   filePath: string
   fingerprint: Fingerprint
+  // folderId из frontmatter: у заметок он приоритетнее пути и может
+  // указывать на несуществующую папку (dangling).
+  folderId: number | null
   id: number
   kind: 'note' | 'snippet'
   space: Extract<VaultDoctorSpace, 'code' | 'http' | 'notes'>
@@ -343,6 +346,7 @@ function inspectMarkdownEntity(input: {
     ? {
         filePath: input.filePath,
         fingerprint,
+        folderId: normalizeId(parsed.frontmatter.folderId),
         id,
         kind: input.kind,
         space: input.space,
@@ -419,6 +423,49 @@ function getStateIds(
   }
 
   return loadHttpState(getHttpPaths(vaultPath)).requests.map(item => item.id)
+}
+
+function getStateIndexedFilePaths(
+  space: Extract<VaultDoctorSpace, 'code' | 'http' | 'notes'>,
+): Set<string> {
+  const vaultPath = getVaultPath()
+
+  const filePaths
+    = space === 'code'
+      ? loadState(getPaths(vaultPath)).snippets.map(item => item.filePath)
+      : space === 'notes'
+        ? loadNotesState(getNotesPaths(vaultPath)).notes.map(
+            item => item.filePath,
+          )
+        : loadHttpState(getHttpPaths(vaultPath)).requests.map(
+            item => item.filePath,
+          )
+
+  return new Set(filePaths.map(filePath => filePath.toLowerCase()))
+}
+
+// Файл с валидным frontmatter-id, которого нет в state-индексе, приложение
+// не отображает до полного пересканирования: Doctor предлагает регистрацию
+// (apply выполняет пересинк пространства, который заберёт файл в индекс).
+function collectUnindexedFiles(
+  context: ScanContext,
+  space: Extract<VaultDoctorSpace, 'code' | 'http' | 'notes'>,
+  records: EntityScanRecord[],
+): void {
+  const indexedFilePaths = getStateIndexedFilePaths(space)
+
+  for (const record of records) {
+    if (!indexedFilePaths.has(record.filePath.toLowerCase())) {
+      addItem(context, {
+        action: 'register-file',
+        fingerprint: record.fingerprint,
+        kind: record.kind,
+        path: record.filePath,
+        space,
+        status: 'pending',
+      })
+    }
+  }
 }
 
 function getNextEntityId(
@@ -586,15 +633,40 @@ function scanCode(context: ScanContext): void {
   })
 
   collectDuplicateIds(context, records)
+  collectUnindexedFiles(context, 'code', records)
+}
+
+function readNotesFolderIdFromMetadata(metaPath: string): number | null {
+  // Недокачанный .meta.yaml не читается синхронно: id папки в этот прогон
+  // не получить, заметки этой папки не считаются dangling.
+  if (getFileAvailability(metaPath).isCloudPlaceholder) {
+    enqueueCloudDownload(metaPath)
+    return null
+  }
+
+  try {
+    const parsed = yaml.load(fs.readFileSync(metaPath, 'utf8')) as {
+      id?: unknown
+    } | null
+    return normalizeId(parsed?.id)
+  }
+  catch {
+    return null
+  }
 }
 
 function scanNotes(context: ScanContext): void {
   const paths = getNotesPaths(getVaultPath())
   const records: EntityScanRecord[] = []
+  const diskFolderIds = new Set<number>()
+  let hasUnreadableFolderMetadata = false
 
   listFolders(paths.notesRoot).forEach((folderPath) => {
     const metaPath = path.join(paths.notesRoot, folderPath, META_FILE_NAME)
     if (!fs.pathExistsSync(metaPath)) {
+      // Папка без метаданных получит id при следующем синке: судить о
+      // dangling-ссылках в этот прогон нельзя.
+      hasUnreadableFolderMetadata = true
       addItem(
         context,
         createFileItem({
@@ -606,6 +678,15 @@ function scanNotes(context: ScanContext): void {
           status: 'pending',
         }),
       )
+      return
+    }
+
+    const folderId = readNotesFolderIdFromMetadata(metaPath)
+    if (folderId) {
+      diskFolderIds.add(folderId)
+    }
+    else {
+      hasUnreadableFolderMetadata = true
     }
   })
 
@@ -628,6 +709,21 @@ function scanNotes(context: ScanContext): void {
   })
 
   collectDuplicateIds(context, records)
+  collectUnindexedFiles(context, 'notes', records)
+
+  // folderId во frontmatter приоритетнее пути (см. readNoteFromFile):
+  // ссылка на несуществующую папку делает заметку невидимой в дереве папок.
+  if (!hasUnreadableFolderMetadata) {
+    for (const record of records) {
+      if (record.folderId && !diskFolderIds.has(record.folderId)) {
+        addWarning(context, {
+          code: 'DANGLING_FOLDER_ID',
+          path: record.filePath,
+          space: 'notes',
+        })
+      }
+    }
+  }
 }
 
 function scanHttp(context: ScanContext): void {
@@ -688,6 +784,7 @@ function scanHttp(context: ScanContext): void {
   }
 
   collectDuplicateIds(context, records)
+  collectUnindexedFiles(context, 'http', records)
 }
 
 function normalizeMathSheet(

--- a/src/main/storage/providers/markdown/http/runtime/parser.ts
+++ b/src/main/storage/providers/markdown/http/runtime/parser.ts
@@ -247,6 +247,10 @@ export function ensureRequestDetailsLoaded(
   httpRoot: string,
   record: HttpRequestRecord,
 ): boolean {
+  if (record.pendingCloudDownload) {
+    return false
+  }
+
   if (!record.detailsPending) {
     return true
   }
@@ -290,7 +294,7 @@ export function writeRequestFile(
 
   // Запись в недокачанный файл затёрла бы облачное содержимое: файл сначала
   // докачивается в фоне.
-  if (availability.isCloudPlaceholder) {
+  if (record.pendingCloudDownload || availability.isCloudPlaceholder) {
     enqueueCloudDownload(absolutePath)
     return
   }

--- a/src/main/storage/providers/markdown/http/runtime/sync.ts
+++ b/src/main/storage/providers/markdown/http/runtime/sync.ts
@@ -218,6 +218,7 @@ function buildRequestFromIndexMetadata(
   relativePath: string,
   meta: HttpRequestIndexMetadata,
   folderId: number | null,
+  options?: { pendingCloudDownload?: boolean },
 ): HttpRequestRecord {
   // Enum-поля нормализуются: .state.yaml мог быть правлен извне, а мусорное
   // значение уронило бы валидацию DTO целого списка.
@@ -240,6 +241,7 @@ function buildRequestFromIndexMetadata(
     createdAt: meta.createdAt,
     updatedAt: meta.updatedAt,
     detailsPending: true,
+    ...(options?.pendingCloudDownload ? { pendingCloudDownload: true } : {}),
   }
 }
 
@@ -266,11 +268,20 @@ function reconcileRequests(
   const indexEntries: HttpState['requests'] = []
   const now = Date.now()
 
+  const resolveFolderId = (relativePath: string): number | null => {
+    const dirPath = path.posix.dirname(relativePath)
+    return dirPath && dirPath !== '.'
+      ? (folderIdByPath.get(dirPath) ?? null)
+      : null
+  }
+
   // Файл, содержимое которого сейчас недоступно (облачный плейсхолдер или
   // сбой чтения), не читается синхронно: он уходит в фоновую докачку,
   // которая триггерит повторный sync http-пространства. Уже известный
   // запрос при этом сохраняет свою запись в индексе (вместе с метаданными),
   // иначе он «исчез» бы из state и после докачки получил бы новый id.
+  // Если метаданные известны, запрос сразу виден в списке placeholder-
+  // записью — как сниппеты и заметки.
   const keepUnavailableRequest = (
     absolutePath: string,
     relativePath: string,
@@ -285,14 +296,19 @@ function reconcileRequests(
         id: knownEntry.id,
         ...(knownEntry.meta ? { meta: knownEntry.meta } : {}),
       })
-    }
-  }
 
-  const resolveFolderId = (relativePath: string): number | null => {
-    const dirPath = path.posix.dirname(relativePath)
-    return dirPath && dirPath !== '.'
-      ? (folderIdByPath.get(dirPath) ?? null)
-      : null
+      if (isValidHttpRequestIndexMetadata(knownEntry.meta)) {
+        records.push(
+          buildRequestFromIndexMetadata(
+            knownEntry.id,
+            relativePath,
+            knownEntry.meta,
+            resolveFolderId(relativePath),
+            { pendingCloudDownload: true },
+          ),
+        )
+      }
+    }
   }
 
   for (const relativePath of requestRelativePaths) {

--- a/src/main/storage/providers/markdown/http/runtime/types.ts
+++ b/src/main/storage/providers/markdown/http/runtime/types.ts
@@ -101,6 +101,11 @@ export interface HttpRequestRecord {
    * наружу через API не отдаётся — все выдающие потоки материализуют.
    */
   detailsPending?: boolean
+  /**
+   * Файл запроса — облачный плейсхолдер: содержимое ещё не скачано
+   * провайдером, запись показывается в списке и докачивается в фоне.
+   */
+  pendingCloudDownload?: boolean
 }
 
 export interface HttpEnvironmentRecord {

--- a/src/main/storage/providers/markdown/http/storages/__tests__/requests.test.ts
+++ b/src/main/storage/providers/markdown/http/storages/__tests__/requests.test.ts
@@ -5,6 +5,7 @@ import yaml from 'js-yaml'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { stateContentCacheByPath } from '../../../runtime/cache'
+import { setDatalessProbeForTests } from '../../../runtime/shared/cloudFiles'
 import { flushPendingStateWrites } from '../../../runtime/shared/stateWriter'
 import { getHttpPaths } from '../../runtime/paths'
 import { ensureHttpStateFile } from '../../runtime/state'
@@ -63,6 +64,11 @@ vi.mock('electron', () => ({
   },
 }))
 
+vi.mock('../../../cloudDownloads', () => ({
+  enqueueCloudDownload: vi.fn(),
+  prioritizeCloudDownload: vi.fn(),
+}))
+
 vi.mock('../../../../../../store', () => ({
   store: {
     preferences: {
@@ -87,6 +93,7 @@ describe('http requests storage', () => {
   })
 
   afterEach(() => {
+    setDatalessProbeForTests(null)
     resetHttpRuntimeCache()
     fs.removeSync(tempVaultPath)
     tempVaultPath = ''
@@ -175,6 +182,40 @@ describe('http requests storage', () => {
 
     expect(record?.name).toBe('Frozen')
     expect(record?.detailsPending).toBe(true)
+  })
+
+  it('lists cloud placeholder requests from index metadata', () => {
+    const storage = createHttpRequestsStorage()
+    const { id } = storage.createRequest({ name: 'Offloaded' })
+    storage.updateRequest(id, { url: 'https://example.com' })
+
+    resyncTwiceForLazyRequests()
+
+    // Провайдер «выгрузил» файл: содержимое заменяется sparse-плейсхолдером
+    // (size > 0, blocks 0), точная проверка dataless подменяется.
+    const paths = getHttpPaths(tempVaultPath)
+    const filePath = getHttpRuntimeCache(paths).requestById.get(id)!.filePath
+    const absolutePath = path.join(paths.httpRoot, filePath)
+    fs.removeSync(absolutePath)
+    const fd = fs.openSync(absolutePath, 'w')
+    fs.ftruncateSync(fd, 4096)
+    fs.closeSync(fd)
+
+    const stats = fs.statSync(absolutePath)
+    if (stats.size === 0 || stats.blocks !== 0) {
+      // На ФС без поддержки sparse-файлов сценарий невоспроизводим.
+      return
+    }
+    setDatalessProbeForTests(() => true)
+
+    resetHttpRuntimeCache()
+    const listed = createHttpRequestsStorage().getRequests()
+    const record = listed.find(request => request.id === id)
+
+    // Недокачанный запрос виден в списке по метаданным индекса.
+    expect(record?.pendingCloudDownload).toBe(true)
+    expect(record?.name).toBe('Offloaded')
+    expect(record?.url).toBe('https://example.com')
   })
 
   it('re-reads the file when index metadata misses bodyType', () => {

--- a/src/main/storage/providers/markdown/http/storages/requests.ts
+++ b/src/main/storage/providers/markdown/http/storages/requests.ts
@@ -12,6 +12,7 @@ import type {
 } from '../runtime/types'
 import path from 'node:path'
 import fs from 'fs-extra'
+import { prioritizeCloudDownload } from '../../cloudDownloads'
 import { normalizeFlag } from '../../runtime/normalizers'
 import { getVaultPath } from '../../runtime/paths'
 import { throwCloudContentUnavailable } from '../../runtime/shared/cloudGuards'
@@ -191,6 +192,12 @@ export function createHttpRequestsStorage(): HttpRequestsStorage {
       const paths = resolvePaths()
       const { requestById } = getCache()
       const request = requestById.get(id) ?? null
+
+      // Пользователь открыл ещё не докачанный запрос: его файл поднимается
+      // в начало очереди фоновой докачки, ответ при этом не блокируется.
+      if (request?.pendingCloudDownload) {
+        prioritizeCloudDownload(path.join(paths.httpRoot, request.filePath))
+      }
 
       // Запись из индекса без тела: body и description дочитываются по
       // первому запросу.

--- a/src/renderer/components/http/RequestEditorPane.vue
+++ b/src/renderer/components/http/RequestEditorPane.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useHttpRequests, useResizeHandle } from '@/composables'
-import { store } from '@/electron'
+import { i18n, store } from '@/electron'
 
 const { currentRequest, isCurrentRequestLoadingVisible } = useHttpRequests()
 
@@ -77,7 +77,11 @@ useResizeHandle(responseHandleRef, {
     ref="rootRef"
     class="relative flex h-full flex-col overflow-hidden pt-[var(--content-top-offset)]"
   >
-    <UiLoadingOverlay v-if="isCurrentRequestLoadingVisible" />
+    <UiLoadingOverlay
+      v-if="currentRequest?.pendingCloudDownload"
+      :label="i18n.t('cloudDownloads.itemPending')"
+    />
+    <UiLoadingOverlay v-else-if="isCurrentRequestLoadingVisible" />
     <div
       class="min-h-0 flex-1"
       :class="{

--- a/src/renderer/components/http/RequestsListItem.vue
+++ b/src/renderer/components/http/RequestsListItem.vue
@@ -12,6 +12,7 @@ import { i18n, ipc } from '@/electron'
 import { isMac } from '@/utils'
 import { onClickOutside, useClipboard } from '@vueuse/core'
 import { format } from 'date-fns'
+import { CloudDownload } from 'lucide-vue-next'
 import { api } from '~/renderer/services/api'
 import { buildHttpPreview } from './requestPreview'
 
@@ -73,6 +74,12 @@ const revealInFileManagerLabel = computed(() =>
   isMac
     ? i18n.t('action.reveal.inFinder')
     : i18n.t('action.reveal.inFileManager'),
+)
+
+// Содержимое ещё в облаке: мутации (запись файла) и копирование превью
+// недоступны до докачки; чтение метаданных и ссылки работают.
+const isCloudPending = computed(
+  () => props.request.pendingCloudDownload === true,
 )
 
 const previewVariables = computed<Record<string, string>>(() => {
@@ -237,7 +244,7 @@ onClickOutside(itemRef, () => {
       'is-focused': isFocused,
       'is-highlighted': isHighlighted,
     }"
-    draggable="true"
+    :draggable="!isCloudPending"
     @click="onClick"
     @contextmenu="onClickContextMenu"
     @dragstart.stop="onDragStart"
@@ -254,6 +261,11 @@ onClickOutside(itemRef, () => {
             <UiText class="title flex-1 truncate text-sm">
               {{ props.request.name }}
             </UiText>
+            <CloudDownload
+              v-if="isCloudPending"
+              class="text-muted-foreground h-3.5 w-3.5 shrink-0 self-center"
+              :aria-label="i18n.t('cloudDownloads.label')"
+            />
           </div>
           <UiText
             as="div"
@@ -280,7 +292,10 @@ onClickOutside(itemRef, () => {
       </ContextMenu.ContextMenuTrigger>
       <ContextMenu.ContextMenuContent>
         <template v-if="!isTrashLibrarySelected">
-          <ContextMenu.ContextMenuItem @click="onAddFavorites">
+          <ContextMenu.ContextMenuItem
+            :disabled="isCloudPending"
+            @click="onAddFavorites"
+          >
             {{
               isRemoveFavoritesAction
                 ? i18n.t("action.remove.fromFavorites")
@@ -292,7 +307,10 @@ onClickOutside(itemRef, () => {
         <ContextMenu.ContextMenuItem @click="onRevealInFileManager">
           {{ revealInFileManagerLabel }}
         </ContextMenu.ContextMenuItem>
-        <ContextMenu.ContextMenuItem @click="onCopyRequest">
+        <ContextMenu.ContextMenuItem
+          :disabled="isCloudPending"
+          @click="onCopyRequest"
+        >
           {{ i18n.t("action.copy.request") }}
         </ContextMenu.ContextMenuItem>
         <ContextMenu.ContextMenuItem @click="onCopyRequestLink">
@@ -300,13 +318,16 @@ onClickOutside(itemRef, () => {
         </ContextMenu.ContextMenuItem>
         <ContextMenu.ContextMenuSeparator />
         <ContextMenu.ContextMenuItem
-          :disabled="isDuplicateDisabled"
+          :disabled="isDuplicateDisabled || isCloudPending"
           @click="onDuplicate"
         >
           {{ i18n.t("action.duplicate") }}
         </ContextMenu.ContextMenuItem>
         <ContextMenu.ContextMenuSeparator />
-        <ContextMenu.ContextMenuItem @click="onDelete">
+        <ContextMenu.ContextMenuItem
+          :disabled="isCloudPending"
+          @click="onDelete"
+        >
           {{
             isTrashLibrarySelected
               ? i18n.t("action.delete.common")
@@ -315,6 +336,7 @@ onClickOutside(itemRef, () => {
         </ContextMenu.ContextMenuItem>
         <ContextMenu.ContextMenuItem
           v-if="isTrashLibrarySelected"
+          :disabled="isCloudPending"
           @click="onRestore"
         >
           {{ i18n.t("action.restore") }}

--- a/src/renderer/services/api/generated/index.ts
+++ b/src/renderer/services/api/generated/index.ts
@@ -636,6 +636,7 @@ export interface HttpRequestItemResponse {
   filePath: string;
   isFavorites: number;
   isDeleted: number;
+  pendingCloudDownload?: boolean;
   createdAt: number;
   updatedAt: number;
 }
@@ -707,6 +708,7 @@ export type HttpRequestsResponse = {
   filePath: string;
   isFavorites: number;
   isDeleted: number;
+  pendingCloudDownload?: boolean;
   createdAt: number;
   updatedAt: number;
 }[];


### PR DESCRIPTION
Closes two known gaps in vault visibility:

- Cloud-offloaded http requests now appear in the list as placeholder entries built from the metadata index (name, method, url), with a cloud icon, disabled mutations and a locked editor until hydration — previously they silently disappeared until download completed
- Vault Doctor now cross-checks disk files against the state index: files with a valid frontmatter id that are missing from the index are reported as pending registrations (apply re-syncs the space); notes whose frontmatter folderId points to a missing folder produce a DANGLING_FOLDER_ID warning