### PR TITLE
test: fix broken mocks and stale expectations for a green full run

### DIFF
--- a/src/main/ipc/handlers/__tests__/system.test.ts
+++ b/src/main/ipc/handlers/__tests__/system.test.ts
@@ -29,6 +29,19 @@ vi.mock('electron', () => ({
   app: {
     relaunch,
     quit,
+    // Транзитивный импорт main-меню читает версию при инициализации модуля.
+    getVersion: vi.fn(() => '0.0.0-test'),
+  },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => []),
+    getFocusedWindow: vi.fn(() => null),
+  },
+  Menu: {
+    buildFromTemplate: vi.fn(() => ({})),
+    setApplicationMenu: vi.fn(),
+  },
+  dialog: {
+    showMessageBox: vi.fn(),
   },
   ipcMain: {
     handle,
@@ -70,6 +83,8 @@ vi.mock('../../../storage/providers/markdown/runtime/paths', () => ({
 vi.mock('../../../store', () => ({
   store: {
     preferences: {
+      // Транзитивный импорт i18n читает локаль при инициализации модуля.
+      get: vi.fn(),
       set: preferencesSet,
     },
   },

--- a/src/renderer/composables/__tests__/useSnippetsSearch.test.ts
+++ b/src/renderer/composables/__tests__/useSnippetsSearch.test.ts
@@ -34,6 +34,14 @@ async function setup(options: SetupOptions = {}) {
     data: [{ contents: [], id: 1, name: 'Search result', tags: [] }],
   }))
 
+  // useContentSort читает store.app при импорте модуля: мокается целиком,
+  // чтобы не тянуть electron store в тест.
+  vi.doMock('@/composables/useContentSort', () => ({
+    useContentSort: () => ({
+      getContentSortQuery: () => ({}),
+    }),
+  }))
+
   vi.doMock('@/composables/useDonations', () => ({
     useDonations: () => ({
       incrementCopy: vi.fn(),

--- a/src/renderer/composables/math-notebook/math-engine/__tests__/format.test.ts
+++ b/src/renderer/composables/math-notebook/math-engine/__tests__/format.test.ts
@@ -51,15 +51,16 @@ describe('formatMathNumber', () => {
 describe('formatMathDate', () => {
   const date = new Date(2026, 2, 28) // March 28, 2026
 
+  // Время форматируется без секунд (hour + minute, см. formatMathDate).
   it('formats date with en-US locale', () => {
-    expect(formatMathDate(date, 'en-US')).toBe('3/28/2026, 12:00:00 AM')
+    expect(formatMathDate(date, 'en-US')).toBe('3/28/2026, 12:00 AM')
   })
 
   it('formats date with de-DE locale', () => {
-    expect(formatMathDate(date, 'de-DE')).toBe('28.3.2026, 0:00:00')
+    expect(formatMathDate(date, 'de-DE')).toBe('28.3.2026, 0:00')
   })
 
   it('formats date with ru-RU locale', () => {
-    expect(formatMathDate(date, 'ru-RU')).toBe('28.03.2026, 0:00:00')
+    expect(formatMathDate(date, 'ru-RU')).toBe('28.03.2026, 0:00')
   })
 })

--- a/src/renderer/ipc/listeners/__tests__/deepLinks.test.ts
+++ b/src/renderer/ipc/listeners/__tests__/deepLinks.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, ref } from 'vue'
+import { computed, reactive, ref } from 'vue'
 
 interface SetupOptions {
   httpRequestResponse?: any
@@ -138,6 +138,11 @@ async function setup(options: SetupOptions = {}) {
       focusedRequestId: ref<number | undefined>(),
       highlightedFolderIds: ref(new Set<number>()),
       highlightedRequestIds: ref(new Set<number>()),
+      httpState: reactive<{
+        folderId?: number
+        libraryFilter?: string
+        requestId?: number
+      }>({}),
       isHttpSpaceInitialized,
     }),
     useHttpFolders: () => ({
@@ -200,6 +205,28 @@ async function setup(options: SetupOptions = {}) {
       }),
       selectSnippet,
     }),
+  }))
+
+  // deepLinks импортирует '@/electron' напрямую: без мока модуль падает на
+  // window.electron в node-окружении.
+  vi.doMock('@/electron', () => ({
+    i18n: {
+      t: (key: string) => key,
+    },
+    ipc: {
+      invoke: vi.fn(),
+      on: vi.fn(),
+    },
+    store: {
+      app: {
+        get: vi.fn(),
+        set: vi.fn(),
+      },
+      preferences: {
+        get: vi.fn(),
+        set: vi.fn(),
+      },
+    },
   }))
 
   vi.doMock('@/services/api', () => ({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,11 @@
 import path from 'node:path'
+import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  // Renderer-модули транзитивно импортируют .vue (например, useSonner →
+  // Sonner.vue): без vue-плагина такие тесты падают на import analysis.
+  plugins: [vue()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src/renderer'),


### PR DESCRIPTION
Restores a fully green `vitest run src` (126 files / 1465 tests, was 24 failures). No production code changes:

- ipc handlers system.test: store mock lacked preferences.get (transitive i18n import), electron mock lacked app.getVersion and menu objects
- deepLinks.test: @/electron was not mocked at all (crashed on window.electron in node env), useHttpApp mock lacked httpState
- useSnippetsSearch.test: useContentSort reads store.app at module import — mocked the composable
- useNoteFolders.test: import chain reaches a .vue SFC (useSonner → Sonner.vue) — added @vitejs/plugin-vue to vitest config, which also unblocks future component tests
- math format.test: stale expectations from #710 — seconds were intentionally dropped from date formatting in #715