### PR TITLE
feat(i18n): add Korean locale

### DIFF
--- a/src/main/i18n/language.ts
+++ b/src/main/i18n/language.ts
@@ -7,6 +7,7 @@ export const language = {
   fa_IR: 'فارسی',
   fr_FR: 'French',
   ja_JP: '日本語',
+  ko_KR: '한국어',
   pl_PL: 'Polski',
   pt_BR: 'Português (Brasil)',
   ro_RO: 'Română',

--- a/src/main/i18n/locales/ko_KR/devtools.json
+++ b/src/main/i18n/locales/ko_KR/devtools.json
@@ -1,0 +1,243 @@
+{
+  "label": "개발자 도구",
+  "generators": {
+    "label": "생성기",
+    "lorem": {
+      "label": "로렘 입숨 생성기",
+      "description": "자리 표시용 텍스트를 생성합니다",
+      "selectType": "유형 선택",
+      "maxCount": "최대 {{count}}",
+      "types": {
+        "words": "단어",
+        "sentences": "문장",
+        "paragraphs": "문단"
+      }
+    },
+    "json": {
+      "label": "JSON 생성기",
+      "description": "다양한 필드 유형으로 무작위 JSON 데이터를 생성합니다",
+      "fields": "필드",
+      "fieldName": "필드 이름",
+      "selectType": "유형 선택",
+      "addField": "필드 추가",
+      "rowCount": "행 수",
+      "maxRows": "최대 1000",
+      "categories": {
+        "general": "일반",
+        "person": "사람",
+        "internet": "인터넷",
+        "location": "위치",
+        "finance": "금융",
+        "commerce": "커머스",
+        "company": "회사",
+        "lorem": "로렘",
+        "date": "날짜",
+        "number": "숫자",
+        "phone": "전화",
+        "image": "이미지"
+      },
+      "types": {
+        "rowNumber": "행 번호",
+        "firstName": "이름",
+        "lastName": "성",
+        "fullName": "전체 이름",
+        "gender": "성별",
+        "jobTitle": "직함",
+        "email": "이메일 주소",
+        "username": "사용자 이름",
+        "password": "비밀번호",
+        "url": "URL",
+        "ipv4": "IP 주소 v4",
+        "ipv6": "IP 주소 v6",
+        "userAgent": "사용자 에이전트",
+        "city": "도시",
+        "country": "국가",
+        "streetAddress": "도로명 주소",
+        "zipCode": "우편번호",
+        "latitude": "위도",
+        "longitude": "경도",
+        "amount": "금액",
+        "currencyCode": "통화 코드",
+        "creditCardNumber": "신용카드 번호",
+        "productName": "제품명",
+        "price": "가격",
+        "department": "부서",
+        "companyName": "회사명",
+        "catchPhrase": "캐치프레이즈",
+        "word": "단어",
+        "sentence": "문장",
+        "paragraph": "문단",
+        "past": "과거 날짜",
+        "future": "미래 날짜",
+        "recent": "최근 날짜",
+        "birthdate": "생년월일",
+        "int": "정수",
+        "float": "부동소수점",
+        "boolean": "불리언",
+        "phoneNumber": "전화번호",
+        "imei": "IMEI",
+        "avatar": "아바타 URL",
+        "imageUrl": "이미지 URL"
+      }
+    }
+  },
+  "converters": {
+    "label": "변환기",
+    "caseConverter": {
+      "label": "케이스 변환기",
+      "description": "텍스트를 다른 케이스로 변환합니다",
+      "caseType": {
+        "uppercase": "대문자",
+        "lowercase": "소문자",
+        "camelcase": "카멜 케이스",
+        "capitalize": "첫 글자 대문자",
+        "constantcase": "상수 케이스",
+        "snakecase": "스네이크 케이스",
+        "kebabcase": "케밥 케이스",
+        "pascalcase": "파스칼 케이스",
+        "dotcase": "닷 케이스",
+        "pathcase": "패스 케이스"
+      }
+    },
+    "textToUnicode": {
+      "label": "텍스트 ↔ 유니코드",
+      "description": "텍스트를 유니코드로, 또는 그 반대로 변환합니다",
+      "modes": {
+        "textToUnicode": "텍스트 → 유니코드",
+        "unicodeToText": "유니코드 → 텍스트"
+      }
+    },
+    "textToAscii": {
+      "label": "텍스트 ↔ ASCII 이진수",
+      "description": "텍스트를 ASCII 이진수로, 또는 그 반대로 변환합니다",
+      "modes": {
+        "textToAscii": "텍스트 → ASCII",
+        "asciiToText": "ASCII → 텍스트"
+      }
+    },
+    "base64": {
+      "label": "Base64 인코더 / 디코더",
+      "description": "텍스트를 Base64로 인코딩하거나 디코딩합니다",
+      "modes": {
+        "textToBase64": "텍스트 → Base64",
+        "base64ToText": "Base64 → 텍스트"
+      }
+    },
+    "jsonToYaml": {
+      "label": "JSON ↔ YAML",
+      "description": "JSON을 YAML로, 또는 그 반대로 변환합니다",
+      "modes": {
+        "jsonToYaml": "JSON → YAML",
+        "yamlToJson": "YAML → JSON"
+      }
+    },
+    "jsonToToml": {
+      "label": "JSON ↔ TOML",
+      "description": "JSON을 TOML로, 또는 그 반대로 변환합니다",
+      "modes": {
+        "jsonToToml": "JSON → TOML",
+        "tomlToJson": "TOML → JSON"
+      }
+    },
+    "jsonToXml": {
+      "label": "JSON ↔ XML",
+      "description": "JSON을 XML로, 또는 그 반대로 변환합니다",
+      "modes": {
+        "jsonToXml": "JSON → XML",
+        "xmlToJson": "XML → JSON"
+      }
+    },
+    "colorConverter": {
+      "label": "색상 변환기",
+      "description": "색상을 다른 형식으로 변환합니다"
+    }
+  },
+  "crypto": {
+    "label": "암호화 / 보안",
+    "hash": {
+      "label": "해시 생성기",
+      "description": "텍스트로부터 해시를 생성합니다"
+    },
+    "hmac": {
+      "label": "HMAC 생성기",
+      "description": "키와 메시지로 구성된 해시 기반 메시지 인증 코드(HMAC)를 생성합니다"
+    },
+    "password": {
+      "label": "비밀번호 생성기",
+      "description": "안전한 비밀번호를 생성합니다"
+    },
+    "uuid": {
+      "label": "UUID 생성기",
+      "description": "범용 고유 식별자(UUID)를 생성합니다"
+    }
+  },
+  "web": {
+    "label": "웹",
+    "urlParser": {
+      "label": "URL 파서",
+      "description": "URL을 구성 요소로 분석합니다"
+    },
+    "urlEncoder": {
+      "label": "URL 인코더 / 디코더",
+      "description": "URL을 인코딩하거나 디코딩합니다",
+      "modes": {
+        "urlEncode": "URL 인코딩",
+        "urlDecode": "URL 디코딩"
+      }
+    },
+    "slugify": {
+      "label": "슬러그화",
+      "description": "텍스트를 URL에 적합한 슬러그로 변환합니다"
+    }
+  },
+  "compare": {
+    "label": "비교",
+    "jsonDiff": {
+      "label": "JSON Diff",
+      "description": "두 JSON 문서 간의 차이를 비교하고 시각화합니다",
+      "original": "원본",
+      "modified": "수정됨",
+      "filters": {
+        "added": "추가됨",
+        "removed": "삭제됨",
+        "modified": "수정됨"
+      },
+      "empty": "두 필드에 JSON을 붙여넣으면 diff가 표시됩니다",
+      "errors": {
+        "invalidJson": "유효하지 않은 JSON",
+        "diffFailed": "diff 계산에 실패했습니다"
+      }
+    }
+  },
+  "form": {
+    "input": "입력",
+    "output": "출력",
+    "inputString": "입력 문자열",
+    "outputString": "출력 문자열",
+    "inputUrl": "입력 URL",
+    "outputUrl": "출력 URL",
+    "parsedUrl": "분석된 URL",
+    "splitQueryString": "쿼리 문자열 분리",
+    "key": "키",
+    "value": "값",
+    "component": "구성 요소",
+    "result": "결과",
+    "secretKey": "비밀 키",
+    "algorithm": "알고리즘",
+    "version": "버전",
+    "amount": "금액",
+    "type": "유형",
+    "length": "길이",
+    "options": "옵션",
+    "numbers": "숫자",
+    "symbols": "기호",
+    "lowercase": "소문자",
+    "uppercase": "대문자",
+    "placeholder": {
+      "text": "텍스트 입력",
+      "value": "값 입력",
+      "secretKey": "비밀 키 입력",
+      "url": "URL 입력"
+    }
+  }
+}

--- a/src/main/i18n/locales/ko_KR/menu.json
+++ b/src/main/i18n/locales/ko_KR/menu.json
@@ -1,0 +1,102 @@
+{
+  "app": {
+    "label": "massCode",
+    "preferences": "환경설정",
+    "devtools": "개발자 도구",
+    "update": "업데이트 확인...",
+    "quit": "massCode 종료",
+    "about": "massCode 정보",
+    "hide": "massCode 숨기기",
+    "mathNotebook": "수학 노트북"
+  },
+  "help": {
+    "label": "도움말",
+    "website": "웹사이트",
+    "documentation": "문서",
+    "viewInGitHub": "GitHub에서 보기",
+    "changeLog": "변경 로그",
+    "reportIssue": "문제 신고",
+    "giveStar": "별점 주기",
+    "extension": {
+      "vscode": "VS Code 확장",
+      "raycast": "Raycast 확장",
+      "alfred": "Alfred 확장"
+    },
+    "donate": {
+      "openCollective": "Open Collective에서 후원하기",
+      "payPal": "PayPal로 후원하기",
+      "gumroad": "Gumroad로 후원하기 (Visa, Mastercard 등)"
+    },
+    "twitter": "X",
+    "devTools": "개발자 도구 전환",
+    "links": {
+      "snippets": "스니펫 컬렉션"
+    }
+  },
+  "file": {
+    "label": "파일",
+    "new": "새로 만들기"
+  },
+  "view": {
+    "label": "보기",
+    "showSidebar": "사이드바 표시/숨기기",
+    "layout": {
+      "label": "레이아웃",
+      "allPanels": "모든 패널",
+      "listEditor": "목록 + 편집기",
+      "editorOnly": "편집기만"
+    },
+    "sortBy": {
+      "label": "정렬 기준",
+      "dateModified": "수정 날짜",
+      "dateCreated": "생성 날짜",
+      "name": "이름"
+    },
+    "sortOrder": {
+      "label": "정렬 순서",
+      "ascending": "오름차순",
+      "descending": "내림차순"
+    },
+    "compactMode": "간결한 목록",
+    "hideCompletedTasks": "완료된 할 일 숨기기"
+  },
+  "edit": {
+    "label": "편집",
+    "find": "찾기"
+  },
+  "editor": {
+    "label": "편집기",
+    "copySnippet": "스니펫 복사",
+    "copyNote": "노트 복사",
+    "format": "서식",
+    "mode": "모드",
+    "modeRaw": "원본",
+    "modeLivePreview": "실시간 미리 보기",
+    "modePreview": "미리 보기",
+    "previewCode": "코드 미리 보기",
+    "previewScreenshot": "스크린샷 미리 보기",
+    "previewJson": "JSON 미리 보기",
+    "sendRequest": "요청 보내기",
+    "fontSizeIncrease": "글꼴 크기 확대",
+    "fontSizeDecrease": "글꼴 크기 축소",
+    "fontSizeReset": "글꼴 크기 재설정"
+  },
+  "markdown": {
+    "preview": "미리 보기",
+    "previewMarkdown": "마크다운 미리 보기",
+    "presentationMode": "프레젠테이션 모드",
+    "previewMindmap": "마인드맵 미리 보기"
+  },
+  "history": {
+    "label": "기록",
+    "back": "뒤로",
+    "forward": "앞으로"
+  },
+  "devtools": {
+    "label": "개발자 도구"
+  },
+  "window": {
+    "label": "창",
+    "minimize": "최소화"
+  }
+}

--- a/src/main/i18n/locales/ko_KR/messages.json
+++ b/src/main/i18n/locales/ko_KR/messages.json
@@ -1,0 +1,119 @@
+{
+  "confirm": {
+    "delete": "\"{{name}}\"을(를) 삭제하시겠습니까?",
+    "deleteVariable": "\"{{name}}\" 변수를 삭제하시겠습니까?",
+    "deleteUnnamedVariable": "이 변수를 삭제하시겠습니까?",
+    "deletePermanently": "\"{{name}}\"을(를) 영구적으로 삭제하시겠습니까?",
+    "deleteConfirmMultipleSnippets": "선택한 스니펫 {{count}}개를 영구적으로 삭제하시겠습니까?",
+    "emptyTrash": "휴지통에 있는 모든 스니펫을 영구적으로 삭제하시겠습니까?",
+    "convertTaskToNote": "\"{{name}}\"을(를) 다시 노트로 변환할까요?",
+    "moveVaultOverwrite": [
+      "선택한 디렉터리를 덮어쓸까요?",
+      "선택한 디렉터리가 비어 있지 않습니다. 현재 볼트로 내용이 덮어써집니다."
+    ],
+    "migrateToMarkdown": [
+      "마크다운 볼트로 마이그레이션할까요?",
+      "선택한 볼트가 현재 SQLite 라이브러리로 덮어써집니다."
+    ],
+    "vaultDoctorApply": [
+      "볼트 수정 사항을 적용할까요?",
+      "massCode가 안전한 메타데이터 수정과 선택한 중복 ID 결정을 적용합니다. 선택하지 않은 충돌은 건너뜁니다."
+    ]
+  },
+  "success": {
+    "copied": "클립보드에 복사됨",
+    "migrateToMarkdown": "마크다운 볼트로 마이그레이션했습니다. 폴더 {{folders}}개, 스니펫 {{snippets}}개, 태그 {{tags}}개.",
+    "vaultMoved": "볼트를 성공적으로 이동했습니다.",
+    "vaultLoaded": "볼트를 성공적으로 불러왔습니다.",
+    "licenseActivated": "라이선스가 활성화되었습니다. massCode를 후원해 주셔서 감사합니다!",
+    "vaultDoctorApplied": "Vault Doctor가 {{count}}개의 수정 사항을 적용했습니다.",
+    "vaultDoctorClean": "Vault Doctor에서 문제를 찾지 못했습니다."
+  },
+  "warning": {
+    "noUndo": "이 작업은 취소할 수 없습니다.",
+    "allSnippetsMoveToTrash": "이 폴더의 모든 스니펫이 휴지통으로 이동합니다.",
+    "taskPropertiesRemoved": "할 일 상태, 우선순위, 마감일이 제거됩니다.",
+    "deleteTag": "이 작업으로 모든 스니펫에서 해당 태그도 제거됩니다.",
+    "createDb": "다른 폴더를 선택하세요",
+    "htmlCssPreview": "HTML 프래그먼트를 추가해 결과를 확인하세요. 스타일링은 CSS, 상호작용은 JavaScript를 추가하세요.",
+    "codeBlockRenderer": [
+      "Codemirror를 사용할 때 코드 블록에 설정할 언어는 다음 값 중 하나와 일치해야 합니다",
+      "languages"
+    ],
+    "vaultDoctorConflicts": "볼트: 동기화 충돌 {{count}}건에 확인이 필요합니다",
+    "vaultDoctorReview": "검토",
+    "cloudFileNotReady": "이 항목은 아직 클라우드 스토리지에서 동기화되는 중입니다. 잠시 후 다시 시도하세요."
+  },
+  "error": {
+    "migration": "SQLite에서 자동 마이그레이션 실패: {{error}}",
+    "entryNameEmpty": "이름을 비워둘 수 없습니다.",
+    "entryNameLeadingDot": "이름은 마침표로 시작할 수 없습니다.",
+    "entryNameInvalidChars": "이름에 다음 문자를 포함할 수 없습니다: {{- chars}}",
+    "entryNameTrailingDot": "이름은 마침표로 끝날 수 없습니다.",
+    "entryNameWindowsReserved": "이 이름은 Windows에서 예약되어 있습니다.",
+    "entryNameNoteConflict": "이 폴더에 같은 이름의 노트가 이미 있습니다.",
+    "entryNameSnippetConflict": "이 폴더에 같은 이름의 스니펫이 이미 있습니다.",
+    "entryNameRequestConflict": "이 폴더에 같은 이름의 요청이 이미 있습니다.",
+    "entryNameFolderConflict": "이 위치에 같은 이름의 폴더가 이미 있습니다.",
+    "licenseInvalid": "유효하지 않은 라이선스 키입니다"
+  },
+  "description": {
+    "storageVault": "볼트 디렉터리를 선택하세요. 기기 간 동기화를 하려면 iCloud Drive, Google Drive 또는 Dropbox의 폴더를 선택하세요.",
+    "language": "언어 변경을 적용하려면 앱을 다시 시작해야 합니다.",
+    "migrateSqliteUtility": "이전 버전의 massCode.db 파일이 있다면 이 유틸리티로 현재 마크다운 볼트로 데이터를 가져올 수 있습니다."
+  },
+  "special": {
+    "unsponsored": "후원되지 않음"
+  },
+  "donations": {
+    "trigger": {
+      "copy": {
+        "code": "스니펫 {{count}}개 복사됨 🚀",
+        "http": "HTTP 항목 {{count}}개 복사됨 🚀",
+        "notes": "노트 {{count}}개 복사됨 🚀",
+        "math": "수학 결과 {{count}}개 복사됨 🚀",
+        "tools": "도구 출력 {{count}}개 복사됨 🚀",
+        "drawings": "드로잉 항목 {{count}}개 복사됨 🚀"
+      },
+      "created": {
+        "code": "스니펫 {{count}}개 생성됨 🎉",
+        "http": "HTTP 요청 {{count}}개 생성됨 🎉",
+        "notes": "노트 {{count}}개 생성됨 🎉",
+        "math": "시트 {{count}}개 생성됨 🎉",
+        "drawings": "드로잉 {{count}}개 생성됨 🎉"
+      },
+      "sent": {
+        "http": "HTTP 요청 {{count}}개 전송됨 🚀"
+      },
+      "streak_7": {
+        "title": "7일 연속 🔥"
+      },
+      "streak_30": {
+        "title": "massCode와 함께한 한 달 🎊"
+      },
+      "streak_100": {
+        "title": "massCode와 함께한 100일 🏆"
+      }
+    },
+    "body": {
+      "full": "안녕하세요, Anton입니다 👋\n저는 massCode를 혼자 만들고 유지하고 있습니다. 업무에 도움이 되었다면 프로젝트가 계속 성장할 수 있도록 후원해 주세요.",
+      "short": "massCode를 잘 사용하고 계신가요? 프로젝트가 계속 성장할 수 있도록 후원해 주세요."
+    },
+    "actions": {
+      "support": "후원하기",
+      "dismiss": "나중에"
+    }
+  },
+  "release": {},
+  "update": {
+    "available": "새 버전 {{newVersion}}을(를) 다운로드할 수 있습니다.\n현재 버전은 {{oldVersion}}입니다.",
+    "noAvailable": "현재 사용 가능한 업데이트가 없습니다.",
+    "downloading": "업데이트 v{{version}}을(를) 백그라운드에서 다운로드하는 중입니다. 준비되면 다시 시작하라는 메시지가 표시됩니다.",
+    "availableToast": "업데이트 사용 가능",
+    "goToGitHub": "GitHub로 이동",
+    "downloaded": "업데이트 v{{version}}이(가) 준비되었습니다. massCode를 다시 시작해 적용하세요.",
+    "restart": "다시 시작",
+    "whatsNewToast": "massCode v{{version}}의 새로운 기능 보기",
+    "releaseNotes": "릴리스 노트"
+  }
+}

--- a/src/main/i18n/locales/ko_KR/preferences.json
+++ b/src/main/i18n/locales/ko_KR/preferences.json
@@ -1,0 +1,276 @@
+{
+  "label": "환경설정",
+  "storage": {
+    "section": {
+      "main": "일반",
+      "migration": "마이그레이션"
+    },
+    "label": "스토리지",
+    "migrateSqliteToMarkdown": "마크다운 볼트로 마이그레이션",
+    "moveVault": "볼트 이동",
+    "movingVault": "볼트 이동 중...",
+    "count": "개수",
+    "vaultPath": "볼트 경로",
+    "vaultDoctor": {
+      "label": "Vault Doctor",
+      "description": "볼트에서 메타데이터 문제, 동기화 충돌, 안전한 복구 항목을 검사합니다.",
+      "scan": {
+        "label": "볼트 검사",
+        "action": "볼트 스캔",
+        "scanning": "스캔 중..."
+      },
+      "apply": {
+        "action": "수정 사항 적용",
+        "applying": "적용 중..."
+      },
+      "summary": {
+        "safe": "안전한 수정",
+        "conflicts": "충돌",
+        "blocked": "차단됨",
+        "warnings": "경고"
+      },
+      "conflicts": "결정 필요",
+      "decisions": {
+        "duplicateId": "중복 ID: {{id}}",
+        "files": "파일: {{count}}개",
+        "progress": "{{selected}}/{{total}} 해결됨",
+        "choose": "이 ID를 유지할 파일 1개를 선택하세요. 나머지 {{count}}개는 새 고유 ID를 받습니다.",
+        "original": "원본",
+        "copy": "복사본",
+        "keepsId": "ID {{id}} 유지",
+        "newId": "새 ID"
+      },
+      "reason": {
+        "merge-markers": "병합 마커",
+        "invalid-frontmatter": "유효하지 않은 프런트매터",
+        "conflicted-copy": "충돌 사본"
+      },
+      "moreWarnings": "경고 {{count}}건 더 보기",
+      "warnings": "경고"
+    }
+  },
+  "editor": {
+    "label": "코드 편집기",
+    "fontSize": {
+      "label": "글꼴 크기",
+      "description": "코드 편집기의 기본 글꼴 크기(픽셀)입니다."
+    },
+    "fontFamily": {
+      "label": "글꼴",
+      "description": "코드 편집기에 사용할 고정폭 글꼴입니다. 대체 글꼴은 쉼표로 구분하세요."
+    },
+    "wrap": {
+      "label": "줄 바꿈",
+      "description": "편집기 너비에 맞춰 줄을 바꾸거나 가로 스크롤을 허용합니다.",
+      "wordWrap": "자동 줄 바꿈",
+      "off": "끄기"
+    },
+    "tabSize": {
+      "label": "탭 크기",
+      "description": "들여쓰기에 사용할 탭당 공백 수입니다."
+    },
+    "showInvisibles": "숨김 문자 표시",
+    "highlightLine": {
+      "label": "줄 강조",
+      "description": "커서가 위치한 줄을 시각적으로 강조합니다."
+    },
+    "highlightGutter": "거터 강조",
+    "matchBrackets": {
+      "label": "괄호 짝 맞추기",
+      "description": "커서 주변의 짝이 맞는 괄호를 강조합니다."
+    },
+    "prettier": {
+      "label": "Prettier",
+      "trailingComma": {
+        "label": "후행 쉼표",
+        "description": "여러 줄 구조를 포맷팅할 때 후행 쉼표를 추가합니다.",
+        "none": "없음",
+        "all": "모두",
+        "es5": "ES5"
+      },
+      "semi": {
+        "label": "세미콜론",
+        "description": "모든 문장 끝에 세미콜론을 추가합니다."
+      },
+      "singleQuote": {
+        "label": "작은따옴표",
+        "description": "큰따옴표 대신 작은따옴표를 사용합니다."
+      }
+    }
+  },
+  "notesEditor": {
+    "label": "노트",
+    "fontSize": {
+      "label": "글꼴 크기",
+      "description": "노트 편집기의 기본 글꼴 크기(픽셀)입니다."
+    },
+    "fontFamily": {
+      "label": "본문 글꼴",
+      "description": "노트 편집기에 사용할 글꼴입니다. 대체 글꼴은 쉼표로 구분하세요."
+    },
+    "codeFontFamily": {
+      "label": "고정폭 글꼴",
+      "description": "노트 편집기의 인라인 코드와 코드 블록에 사용할 고정폭 글꼴입니다. 대체 글꼴은 쉼표로 구분하세요."
+    },
+    "lineHeight": {
+      "label": "줄 간격",
+      "description": "줄 사이의 간격입니다. 넓게는 가독성이 좋고, 좁게는 더 많은 내용을 표시합니다.",
+      "compact": "좁게 (1.4)",
+      "default": "기본 (1.54)",
+      "relaxed": "넓게 (1.7)"
+    },
+    "indentSize": {
+      "label": "들여쓰기 크기",
+      "description": "목록과 중첩된 내용의 들여쓰기 단계당 공백 수입니다."
+    },
+    "limitWidth": {
+      "label": "너비 제한",
+      "description": "쾌적한 읽기를 위한 최대 콘텐츠 너비(700px)입니다."
+    },
+    "lineNumbers": {
+      "label": "줄 번호",
+      "description": "거터에 줄 번호를 표시합니다. 원본 모드에서만 사용할 수 있습니다."
+    }
+  },
+  "appearance": {
+    "label": "화면",
+    "theme": {
+      "label": "테마",
+      "builtIn": "기본 제공",
+      "custom": "사용자 지정",
+      "themesDir": "테마 디렉터리",
+      "openDir": "테마 디렉터리 열기",
+      "createTemplate": "테마 템플릿 만들기",
+      "dirDescription": "사용자 지정 JSON 테마 파일을 저장하는 디렉터리입니다.",
+      "light": "라이트",
+      "dark": "다크",
+      "system": "시스템"
+    }
+  },
+  "language": {
+    "label": "언어"
+  },
+  "markdown": {
+    "label": "마크다운",
+    "codeRenderer": "코드 블록 렌더러"
+  },
+  "math": {
+    "label": "수학 노트북",
+    "locale": {
+      "label": "지역",
+      "description": "숫자와 날짜 표시 형식입니다."
+    },
+    "decimalPlaces": {
+      "label": "소수 자릿수",
+      "description": "결과에 표시할 최대 소수 자릿수(0~14)입니다."
+    },
+    "dateFormat": {
+      "label": "날짜 형식",
+      "description": "결과에서 날짜가 표시되는 방식입니다."
+    },
+    "currencyRates": {
+      "label": "환율",
+      "description": "1시간 동안 캐시됩니다.",
+      "refresh": "새로고침",
+      "refreshing": "새로고침 중...",
+      "refreshed": "환율이 업데이트되었습니다",
+      "refreshError": "환율 업데이트에 실패했습니다"
+    },
+    "cryptoRates": {
+      "label": "암호화폐 시세",
+      "description": "1시간 동안 캐시됩니다. 속도 제한: 분당 10~30회.",
+      "refresh": "새로고침",
+      "refreshing": "새로고침 중...",
+      "refreshed": "암호화폐 시세가 업데이트되었습니다",
+      "rateLimited": "속도 제한을 초과했습니다. 나중에 다시 시도하세요."
+    }
+  },
+  "tasks": {
+    "label": "할 일",
+    "autoCleanup": {
+      "label": "완료 항목 자동 정리",
+      "description": "일정에 따라 완료된 할 일을 휴지통으로 이동합니다. 휴지통을 비우기 전까지 유지됩니다.",
+      "never": "안 함",
+      "1d": "매일",
+      "7d": "7일마다",
+      "30d": "30일마다"
+    },
+    "cleanupNow": {
+      "label": "지금 정리",
+      "button": "완료 항목을 휴지통으로 이동",
+      "description": "완료된 모든 할 일을 지금 휴지통으로 이동합니다."
+    }
+  },
+  "http": {
+    "label": "HTTP 클라이언트",
+    "wrapLines": {
+      "label": "줄 바꿈",
+      "description": "HTTP 미리 보기, 요청 본문, 응답 뷰어에서 긴 줄을 바꿉니다."
+    },
+    "defaultPreviewFormat": {
+      "label": "기본 미리 보기 형식",
+      "description": "요청 미리 보기 패널에서 기본으로 선택되는 형식입니다.",
+      "http": "HTTP",
+      "curl": "cURL"
+    },
+    "autoSwitchToResponse": {
+      "label": "전송 후 응답 표시",
+      "description": "요청이 시작되거나 완료되면 하단 패널을 응답으로 전환합니다."
+    },
+    "sslCertificateVerification": {
+      "label": "SSL 인증서 검증",
+      "description": "HTTPS 요청을 보낼 때 SSL 인증서를 검증합니다. 끄면 유효하지 않거나 자체 서명된 인증서도 허용합니다."
+    }
+  },
+  "api": {
+    "label": "API",
+    "port": {
+      "label": "API 포트",
+      "description": "API 서버가 사용할 포트 번호입니다(적용하려면 앱을 다시 시작해야 함). 유효 범위: 1024~65535."
+    },
+    "integrations": {
+      "label": "통합",
+      "enabled": {
+        "label": "API 통합 사용",
+        "description": "외부 로컬 클라이언트가 보호된 통합 엔드포인트를 사용할 수 있도록 허용합니다."
+      },
+      "token": {
+        "label": "API 토큰",
+        "description": "외부 클라이언트에서 이 토큰을 사용하세요. 전체 토큰은 생성 직후에만 표시됩니다.",
+        "empty": "생성된 토큰이 없습니다",
+        "generate": "토큰 생성",
+        "revoke": "토큰 취소"
+      }
+    }
+  },
+  "supporter": {
+    "label": "후원자",
+    "status": {
+      "label": "상태",
+      "active": "후원자 라이선스가 활성화되어 있습니다.",
+      "activeFor": "{{name}}님의 후원자 라이선스가 활성화되어 있습니다.",
+      "description": "massCode를 후원해 주셔서 감사합니다! 후원 안내가 꺼져 있습니다."
+    },
+    "key": {
+      "label": "라이선스 키",
+      "placeholder": "후원자 키를 붙여넣으세요",
+      "activate": "활성화",
+      "description": "후원 후 받은 키를 붙여넣으세요. 활성화는 오프라인에서도 작동하며 후원 안내를 제거합니다."
+    },
+    "request": {
+      "label": "아직 키가 없나요?",
+      "action": "키 요청",
+      "description": "어떤 방식으로든 massCode를 후원한 적이 있다면 후원 증빙을 이메일로 보내주시면 키를 받을 수 있습니다."
+    }
+  },
+  "updates": {
+    "label": "업데이트",
+    "autoUpdate": {
+      "label": "자동 업데이트",
+      "description": "업데이트를 백그라운드에서 다운로드하고 다시 시작할 때 설치합니다. 끄면 massCode는 새 버전을 알려주기만 합니다. 주 버전(major version)은 자동으로 설치되지 않습니다."
+    },
+    "version": {
+      "label": "현재 버전"
+    }
+  }
+}

--- a/src/main/i18n/locales/ko_KR/ui.json
+++ b/src/main/i18n/locales/ko_KR/ui.json
@@ -1,0 +1,642 @@
+{
+  "common": {
+    "total": "전체",
+    "inbox": "인박스",
+    "favorites": "즐겨찾기",
+    "trash": "휴지통",
+    "folders": "폴더",
+    "tags": "태그",
+    "library": "라이브러리",
+    "fragment": "프래그먼트"
+  },
+  "commandPalette": {
+    "title": "명령어 팔레트",
+    "description": "스페이스, 스니펫, 노트, HTTP 요청을 검색합니다.",
+    "placeholder": "검색 또는 명령 실행...",
+    "commandPlaceholder": "명령 실행...",
+    "scopedPlaceholder": "{{space}}에서 검색...",
+    "clearScope": "범위 지우기",
+    "clearFilter": "필터 지우기: {{filter}}",
+    "searching": "검색 중...",
+    "empty": "결과가 없습니다",
+    "groups": {
+      "recent": "최근",
+      "actions": "작업",
+      "spaces": "스페이스",
+      "filters": "필터",
+      "results": "결과",
+      "snippets": "스니펫",
+      "notes": "노트",
+      "httpRequests": "HTTP 요청"
+    },
+    "actions": {
+      "importSnippets": "스니펫 가져오기",
+      "importSnippetsSubtitle": "VS Code 스니펫 JSON, Raycast 스니펫 JSON, SnippetsLab JSON 또는 공개 GitHub Gist URL을 가져옵니다",
+      "importNotes": "노트 가져오기",
+      "importNotesSubtitle": "Obsidian 마크다운 폴더를 가져옵니다",
+      "newSnippet": "새 스니펫",
+      "newSnippetSubtitle": "코드 스니펫 만들기",
+      "newNote": "새 노트",
+      "newNoteSubtitle": "노트 만들기",
+      "newHttpRequest": "새 HTTP 요청",
+      "newHttpRequestSubtitle": "HTTP 요청 만들기",
+      "newCodeFolder": "새 코드 폴더",
+      "newCodeFolderSubtitle": "코드에 폴더 만들기",
+      "newNotesFolder": "새 노트 폴더",
+      "newNotesFolderSubtitle": "노트에 폴더 만들기",
+      "newHttpFolder": "새 HTTP 폴더",
+      "newHttpFolderSubtitle": "HTTP에 폴더 만들기",
+      "importHttpCollection": "HTTP 컬렉션 가져오기",
+      "importHttpCollectionSubtitle": "OpenAPI, Postman 또는 Bruno 컬렉션 파일을 가져옵니다",
+      "openPreferences": "환경설정 열기",
+      "openPreferencesSubtitle": "massCode 설정 변경"
+    },
+    "fallbacks": {
+      "createSnippet": "\"{{- query}}\" 스니펫 만들기",
+      "createSnippetSubtitle": "코드 인박스에 만들기",
+      "createNote": "\"{{- query}}\" 노트 만들기",
+      "createNoteSubtitle": "노트 인박스에 만들기",
+      "createHttpRequest": "\"{{- query}}\" HTTP 요청 만들기",
+      "createHttpRequestFromUrl": "URL로 HTTP 요청 만들기",
+      "createHttpRequestSubtitle": "HTTP에 만들기"
+    },
+    "suggestions": {
+      "tagSubtitle": "{{space}}을(를) 태그로 필터링",
+      "folderSubtitle": "{{space}}을(를) 폴더로 필터링"
+    },
+    "actionPanel": {
+      "heading": "작업",
+      "open": "열기",
+      "run": "실행",
+      "copyTitle": "제목 복사",
+      "copySnippetContent": "스니펫 내용 복사",
+      "copyHttpUrl": "URL 복사"
+    },
+    "footer": {
+      "open": "열기",
+      "jump": "이동",
+      "actions": "작업",
+      "apply": "적용",
+      "run": "실행",
+      "back": "뒤로"
+    }
+  },
+  "imports": {
+    "title": {
+      "code": "스니펫 가져오기",
+      "notes": "노트 가져오기"
+    },
+    "description": {
+      "code": "VS Code 스니펫 JSON, Raycast 스니펫 JSON, SnippetsLab JSON, 공개 GitHub Gist URL을 가져옵니다.",
+      "notes": "Obsidian 마크다운 폴더를 가져옵니다."
+    },
+    "action": {
+      "import": "가져오기"
+    },
+    "sources": {
+      "vscode-snippets": "VS Code",
+      "raycast-snippets": "Raycast",
+      "snippetslab": "SnippetsLab",
+      "github-gists": "GitHub Gists",
+      "obsidian": "Obsidian"
+    },
+    "gistUrl": "Gist URL",
+    "gistUrlPlaceholder": "https://gist.github.com/user/id",
+    "filesTitle": "가져올 파일 선택",
+    "folderTitle": "가져올 폴더 선택",
+    "fileHint": "파일을 여기로 드래그하거나 파일을 선택해 가져오기를 미리 봅니다.",
+    "folderHint": "미리 보려면 Obsidian 마크다운 폴더를 선택하세요.",
+    "chooseFiles": "파일 선택",
+    "chooseFolder": "폴더 선택",
+    "preview": "미리 보기",
+    "previewing": "가져오기 읽는 중",
+    "noReadableFiles": "읽을 수 있는 파일이 없습니다. 폴더를 로컬에 다운로드하거나 파일 권한을 확인한 후 다시 시도하세요.",
+    "noImportableFiles": "가져올 수 있는 마크다운 파일이 없습니다.",
+    "snippets": "스니펫",
+    "notes": "노트",
+    "tags": "태그",
+    "detectedSource": "감지된 소스",
+    "folderMeta_one": "{{count}}개 항목",
+    "folderMeta_other": "{{count}}개 항목",
+    "warningTitle": "경고",
+    "warningMessages": {
+      "file": {
+        "readFailed": "파일을 읽을 수 없습니다. 로컬에 다운로드되어 massCode에서 사용할 수 있는지 확인하세요."
+      },
+      "fs": {
+        "folderReadFailed": "폴더를 읽을 수 없습니다. 파일 권한과 iCloud 다운로드 상태를 확인하세요.",
+        "fileReadFailed": "파일을 읽을 수 없습니다. 파일 권한과 iCloud 다운로드 상태를 확인하세요."
+      },
+      "source": {
+        "unsupported": "지원하지 않는 가져오기 소스입니다."
+      },
+      "vscode": {
+        "invalidJson": "유효한 VS Code 스니펫 JSON 객체가 아닙니다.",
+        "entryNotObject": "스니펫 항목이 객체가 아닙니다.",
+        "invalidBody": "스니펫 본문은 문자열 또는 문자열 배열이어야 합니다."
+      },
+      "raycast": {
+        "invalidExport": "유효한 Raycast 스니펫 내보내기 파일이 아닙니다.",
+        "emptyText": "스니펫 텍스트가 비어 있거나 없습니다."
+      },
+      "snippetslab": {
+        "invalidExport": "유효한 SnippetsLab 내보내기 파일이 아닙니다.",
+        "smartGroupsSkipped": "SnippetsLab 스마트 그룹은 가져오지 않습니다.",
+        "attachmentsSkipped": "SnippetsLab 프래그먼트 첨부 파일은 가져오지 않습니다.",
+        "emptySnippet": "SnippetsLab 스니펫에 가져올 수 있는 프래그먼트가 없습니다."
+      },
+      "gist": {
+        "noFiles": "GitHub Gist에 파일이 없습니다.",
+        "truncatedSkipped": "잘린(truncated) Gist 파일은 이번 가져오기 버전에서 건너뜁니다.",
+        "contentMissing": "Gist 파일 내용이 없습니다."
+      },
+      "obsidian": {
+        "excalidrawSkipped": "Excalidraw 마크다운 파일은 건너뛰었습니다.",
+        "emptyMarkdown": "마크다운 파일이 비어 있습니다.",
+        "frontmatterIgnored": "무시된 프런트매터 필드: {{fields}}.",
+        "attachmentsKept": "첨부 파일 참조는 텍스트로 유지되며, 첨부 파일 자체는 가져오지 않습니다.",
+        "wikiLinksKept": "Obsidian 위키 링크는 텍스트로 가져오며 다시 쓰지 않습니다.",
+        "noMarkdownFiles": "Obsidian 가져오기에서 마크다운 파일을 찾을 수 없습니다.",
+        "invalidFrontmatter": "프런트매터를 파싱할 수 없어 노트 내용으로 가져왔습니다."
+      },
+      "unknown": "가져오기 경고."
+    },
+    "import": "가져오기",
+    "importing": "가져오는 중",
+    "importedSnippets_one": "스니펫 {{snippets}}개를 가져왔습니다.",
+    "importedSnippets_other": "스니펫 {{snippets}}개를 가져왔습니다.",
+    "importedNotes_one": "노트 {{notes}}개를 가져왔습니다.",
+    "importedNotes_other": "노트 {{notes}}개를 가져왔습니다.",
+    "createdFolder": "생성됨: {{name}}",
+    "error": "가져오기 실패"
+  },
+  "spaces": {
+    "label": "스페이스",
+    "code": {
+      "label": "코드",
+      "tooltip": "코드 스니펫",
+      "title": "코드 스니펫",
+      "allSnippets": "모든 스니펫"
+    },
+    "notes": {
+      "label": "노트",
+      "tooltip": "노트",
+      "title": "노트",
+      "allNotes": "모든 노트"
+    },
+    "math": {
+      "label": "수학",
+      "tooltip": "수학 노트북",
+      "title": "수학 노트북",
+      "sheetList": "시트 목록",
+      "newSheet": "새 시트",
+      "searchPlaceholder": "시트 검색…",
+      "noResults": "시트를 찾을 수 없습니다",
+      "untitled": "제목 없음",
+      "currencyUnavailable": "환율 서비스를 사용할 수 없습니다",
+      "cloudSyncing": "클라우드 스토리지에서 동기화하는 중…"
+    },
+    "drawings": {
+      "label": "드로잉",
+      "tooltip": "Excalidraw 드로잉",
+      "title": "드로잉",
+      "drawingList": "드로잉 목록",
+      "newDrawing": "새 드로잉",
+      "searchPlaceholder": "드로잉 검색…",
+      "noResults": "드로잉을 찾을 수 없습니다",
+      "fitToContent": "내용에 맞추기",
+      "exportImage": "이미지 내보내기…",
+      "copyLinkForNote": "노트용 링크 복사",
+      "openInSpace": "드로잉에서 열기",
+      "notFound": "드로잉을 찾을 수 없습니다",
+      "noSelected": "선택한 드로잉 없음"
+    },
+    "http": {
+      "label": "HTTP",
+      "tooltip": "HTTP 클라이언트",
+      "title": "HTTP 클라이언트",
+      "allRequests": "모든 요청",
+      "untitledRequest": "제목 없는 요청",
+      "empty": "아직 요청이 없습니다",
+      "noUrl": "URL 없음",
+      "action": {
+        "import": "가져오기",
+        "newRequest": "새 요청",
+        "newEnvironment": "새 환경",
+        "manageEnvironments": "환경 관리",
+        "deleteEnvironment": "환경 삭제"
+      },
+      "environments": {
+        "title": "환경",
+        "none": "환경 없음",
+        "activeTooltip": "환경: {{name}}",
+        "selectTooltip": "환경 선택",
+        "manage": "환경 관리…",
+        "empty": "아직 환경이 없습니다",
+        "untitled": "제목 없는 환경",
+        "namePlaceholder": "환경 이름",
+        "variables": "변수",
+        "noVariables": "아직 변수가 없습니다",
+        "varKey": "변수",
+        "varValue": "값",
+        "addVariable": "변수 추가",
+        "noEnvironmentSelected": "변수를 편집할 환경을 선택하세요"
+      },
+      "import": {
+        "title": "HTTP 컬렉션 가져오기",
+        "description": "OpenAPI JSON/YAML, Postman Collection v2.1 JSON, Postman Environment JSON, Bruno OpenCollection YAML 또는 ZIP 파일을 가져옵니다.",
+        "formats": "가져올 파일 선택",
+        "postman": "Postman 컬렉션",
+        "postmanHint": "컬렉션 JSON 1개와 선택적으로 환경 JSON을 선택하세요.",
+        "fileHint": "파일을 여기로 드래그하거나 파일을 선택해 가져오기를 미리 봅니다.",
+        "chooseFiles": "파일 선택",
+        "previewing": "파일 읽는 중",
+        "collections": "컬렉션",
+        "requests": "요청",
+        "environments": "환경",
+        "collectionMeta": "폴더 {{folders}}개, 요청 {{requests}}개",
+        "variablesMeta": "변수 {{variables}}개",
+        "plainTextNotice": "환경 변수는 볼트에 일반 텍스트로 저장됩니다.",
+        "warnings": "경고",
+        "import": "가져오기",
+        "importing": "가져오는 중",
+        "imported": "컬렉션 {{collections}}개에서 요청 {{requests}}개를 가져왔습니다.",
+        "createdFolders": "생성됨: {{names}}",
+        "error": "가져오기 실패"
+      },
+      "editor": {
+        "noSelected": "선택한 요청 없음",
+        "namePlaceholder": "요청 이름",
+        "urlPlaceholder": "요청 URL 입력",
+        "send": "보내기",
+        "tabs": {
+          "params": "파라미터",
+          "headers": "헤더",
+          "body": "본문",
+          "auth": "인증",
+          "description": "설명"
+        },
+        "keyValue": {
+          "key": "키",
+          "value": "값",
+          "description": "설명",
+          "addRow": "행 추가",
+          "empty": "항목 없음"
+        },
+        "body": {
+          "typeNone": "없음",
+          "typeJson": "JSON",
+          "typeText": "텍스트",
+          "typeFormUrlencoded": "Form URL-encoded",
+          "typeMultipart": "Multipart form-data",
+          "placeholder": "요청 본문 입력",
+          "fieldType": {
+            "text": "텍스트",
+            "file": "파일"
+          },
+          "filePlaceholder": "파일 경로 선택",
+          "jsonInvalid": "유효하지 않은 JSON"
+        },
+        "auth": {
+          "typeNone": "인증 없음",
+          "typeBearer": "Bearer 토큰",
+          "typeBasic": "기본 인증",
+          "token": "토큰",
+          "tokenPlaceholder": "토큰 입력",
+          "username": "사용자 이름",
+          "usernamePlaceholder": "사용자 이름 입력",
+          "password": "비밀번호",
+          "passwordPlaceholder": "비밀번호 입력"
+        },
+        "description": {
+          "placeholder": "이 요청에 대한 설명 추가"
+        },
+        "panels": {
+          "preview": "미리 보기",
+          "response": "응답"
+        },
+        "preview": {
+          "empty": "요청 미리 보기 없음",
+          "formats": {
+            "http": "HTTP",
+            "curl": "cURL"
+          }
+        },
+        "response": {
+          "empty": "아직 응답 없음",
+          "executing": "요청 보내는 중",
+          "status": "상태",
+          "time": "시간",
+          "size": "크기",
+          "tabs": {
+            "body": "본문",
+            "headers": "헤더"
+          },
+          "error": "요청 실패",
+          "noResponse": "응답을 받지 못했습니다",
+          "truncated": "응답이 잘렸습니다",
+          "binaryNotice": "바이너리 응답은 표시되지 않습니다",
+          "copy": "복사",
+          "copied": "복사됨"
+        }
+      }
+    },
+    "tools": {
+      "label": "도구",
+      "tooltip": "개발자 도구"
+    }
+  },
+  "snippet": {
+    "untitled": "제목 없는 스니펫",
+    "selectedMultiple": "스니펫 {{count}}개 선택됨",
+    "noSelected": "선택한 스니펫 없음"
+  },
+  "notes": {
+    "untitled": "제목 없는 노트",
+    "plural": "노트",
+    "words": "단어",
+    "symbols": "기호",
+    "selectedMultiple": "노트 {{count}}개 선택됨",
+    "noSelected": "선택한 노트 없음",
+    "editor": {
+      "menu": {
+        "format": {
+          "title": "서식",
+          "bold": "굵게",
+          "italic": "기울임꼴",
+          "strikethrough": "취소선",
+          "highlight": "형광펜",
+          "code": "코드",
+          "link": "링크",
+          "clearFormatting": "서식 지우기"
+        },
+        "paragraph": {
+          "title": "문단",
+          "bulletList": "글머리 기호 목록",
+          "numberedList": "번호 매기기 목록",
+          "taskList": "할 일 목록",
+          "heading": "제목 {{level}}",
+          "body": "본문",
+          "quote": "인용구"
+        },
+        "insert": {
+          "title": "삽입",
+          "table": "표",
+          "callout": "콜아웃",
+          "horizontalRule": "구분선",
+          "codeBlock": "코드 블록"
+        },
+        "table": {
+          "title": "표",
+          "insertRowAbove": "위에 행 삽입",
+          "insertRowBelow": "아래에 행 삽입",
+          "deleteRow": "행 삭제",
+          "insertColumnLeft": "왼쪽에 열 삽입",
+          "insertColumnRight": "오른쪽에 열 삽입",
+          "deleteColumn": "열 삭제",
+          "alignLeft": "왼쪽 정렬",
+          "alignCenter": "가운데 정렬",
+          "alignRight": "오른쪽 정렬"
+        }
+      },
+      "table": {
+        "addColumn": "오른쪽에 열 추가",
+        "addRow": "아래에 행 추가"
+      }
+    },
+    "tasks": {
+      "title": "할 일",
+      "today": "오늘",
+      "upcoming": "예정",
+      "completed": "완료",
+      "convertToTask": "할 일로 변환",
+      "convertToNote": "노트로 변환",
+      "duePlaceholder": "마감일",
+      "clearDue": "마감일 지우기",
+      "noDue": "마감일 없음",
+      "cleanupCompleted": "완료된 할 일 정리",
+      "cleanupConfirmTitle": "완료된 할 일을 정리할까요?",
+      "cleanupConfirmMessage": "완료된 모든 할 일이 휴지통으로 이동합니다. 휴지통을 비우기 전까지 복원할 수 있습니다.",
+      "cleanupDone": "완료된 할 일 {{count}}개를 휴지통으로 이동했습니다",
+      "cleanupEmpty": "정리할 완료된 할 일이 없습니다",
+      "cleanupError": "완료된 할 일 정리에 실패했습니다",
+      "status": {
+        "todo": "할 일",
+        "inProgress": "진행 중",
+        "done": "완료",
+        "blocked": "차단됨"
+      },
+      "priority": {
+        "label": "우선순위",
+        "none": "우선순위 없음",
+        "low": "낮음",
+        "medium": "보통",
+        "high": "높음"
+      }
+    },
+    "dashboard": {
+      "label": "대시보드",
+      "title": "노트 대시보드",
+      "description": "노트 활동, 링크, 구조를 확인하세요.",
+      "empty": "모든 대시보드 위젯이 숨겨져 있습니다.",
+      "error": "노트 대시보드를 불러오지 못했습니다.",
+      "actions": {
+        "refresh": "새로고침",
+        "backToDashboard": "대시보드로 돌아가기",
+        "showAllWidgets": "모든 위젯 표시"
+      },
+      "widgets": {
+        "title": "표시할 위젯",
+        "description": "대시보드에 표시할 블록을 선택하세요.",
+        "stats": "개요",
+        "activityHeatmap": "활동 히트맵",
+        "recent": "최근 노트",
+        "graphPreview": "노트 그래프",
+        "topLinked": "가장 많이 연결된 노트"
+      },
+      "stats": {
+        "title": "개요",
+        "notes": "노트",
+        "words": "단어",
+        "folders": "폴더",
+        "tags": "태그"
+      },
+      "activity": {
+        "heatmapTitle": "활동 히트맵",
+        "heatmapDescription": "최근 일별 노트 업데이트.",
+        "updatedToday": "오늘 업데이트됨",
+        "updatedWeek": "7일 이내 업데이트됨",
+        "less": "적음",
+        "more": "많음",
+        "totalLastYear": "지난 53주간 노트 업데이트 {{count}}회",
+        "tooltipUpdates": "노트 업데이트 {{count}}회"
+      },
+      "recent": {
+        "title": "최근 노트",
+        "empty": "아직 최근 노트가 없습니다."
+      },
+      "graphPreview": {
+        "title": "노트 그래프",
+        "empty": "아직 노트 간 링크가 없습니다."
+      },
+      "topLinked": {
+        "title": "가장 많이 연결된 노트",
+        "empty": "아직 연결된 노트가 없습니다.",
+        "incoming": "수신 링크 {{count}}개"
+      },
+      "graph": {
+        "title": "노트 그래프",
+        "description": "노트 간 연결을 살펴보고 작업 공간에서 바로 여세요.",
+        "hint": "드래그해서 이동하고, 확대/축소 컨트롤이나 마우스 휠을 사용하며, 노드에 마우스를 올려 주변 노트를 확인하세요.",
+        "meta": "수신 링크 {{links}}개 · 연결된 노트 {{neighbors}}개",
+        "empty": "아직 노트 간 링크가 없습니다.",
+        "error": "노트 그래프를 불러오지 못했습니다."
+      }
+    }
+  },
+  "folder": {
+    "untitled": "제목 없는 폴더",
+    "iconPicker": {
+      "searchPlaceholder": "아이콘 검색...",
+      "emptyResults": "아이콘을 찾을 수 없습니다",
+      "filters": {
+        "all": "전체",
+        "material": "Material",
+        "lucide": "Lucide"
+      }
+    }
+  },
+  "button": {
+    "back": "뒤로",
+    "cancel": "취소",
+    "confirm": "확인",
+    "copy": "복사",
+    "fit": "맞춤",
+    "generate": "생성",
+    "saveAs": "다른 이름으로 저장",
+    "update": [
+      "GitHub로 이동",
+      "확인"
+    ],
+    "zoomIn": "확대",
+    "zoomOut": "축소",
+    "darkMode": "다크 모드",
+    "toggleDarkMode": "다크 모드 전환",
+    "background": "배경",
+    "goToDownload": "다운로드로 이동",
+    "goToSettings": "설정으로 이동",
+    "refreshPreview": "미리 보기 새로고침",
+    "laserPointer": "레이저 포인터",
+    "fullscreen": "전체 화면",
+    "prev": "이전",
+    "next": "다음"
+  },
+  "action": {
+    "close": "닫기",
+    "clearSearch": "검색 지우기",
+    "defaultLanguage": "기본 언어",
+    "duplicate": "복제",
+    "rename": "이름 바꾸기",
+    "restore": "복원",
+    "setCustomIcon": "아이콘 설정",
+    "removeCustomIcon": "아이콘 제거",
+    "show": "표시",
+    "hide": "숨기기",
+    "showSidebar": "사이드바 표시",
+    "hideSidebar": "사이드바 숨기기",
+    "showSidebarAndList": "사이드바 및 목록 표시",
+    "hideSidebarAndList": "사이드바 및 목록 숨기기",
+    "new": {
+      "storage": "새 스토리지",
+      "folder": "새 폴더",
+      "snippet": "새 스니펫",
+      "fragment": "새 프래그먼트",
+      "note": "새 노트",
+      "task": "새 할 일"
+    },
+    "createOptions": "만들기 옵션",
+    "add": {
+      "description": "설명 추가",
+      "tag": "태그 추가",
+      "toFavorites": "즐겨찾기에 추가"
+    },
+    "open": {
+      "storage": "스토리지 열기"
+    },
+    "move": {
+      "storage": "스토리지 이동",
+      "toTrash": "휴지통으로 이동"
+    },
+    "remove": {
+      "fromFavorites": "즐겨찾기에서 제거"
+    },
+    "reveal": {
+      "inFinder": "Finder에서 보기",
+      "inFileManager": "파일 관리자에서 보기"
+    },
+    "reload": {
+      "storage": "스토리지 다시 불러오기",
+      "app": "massCode 다시 시작"
+    },
+    "delete": {
+      "common": "삭제",
+      "now": "지금 삭제",
+      "allData": "모든 데이터 삭제",
+      "trash": "휴지통 비우기"
+    },
+    "migrate": {
+      "fromSnippetsLab": "SnippetsLab에서",
+      "fromV3": "massCode v3에서"
+    },
+    "export": {
+      "toHtml": "HTML로 내보내기"
+    },
+    "copy": {
+      "snippet": "스니펫 복사",
+      "snippetLink": "스니펫 링크 복사",
+      "note": "노트 복사",
+      "noteLink": "노트 링크 복사",
+      "request": "요청 복사",
+      "requestLink": "요청 링크 복사"
+    },
+    "select": {
+      "directory": "디렉터리 선택"
+    }
+  },
+  "internalLinks": {
+    "picker": {
+      "searchPlaceholder": "스니펫, HTTP 요청, 노트 검색...",
+      "emptyResults": "결과 없음",
+      "groups": {
+        "snippets": "스니펫",
+        "httpRequests": "HTTP 요청",
+        "notes": "노트"
+      }
+    },
+    "missing": {
+      "snippet": "스니펫을 찾을 수 없습니다",
+      "httpRequest": "HTTP 요청을 찾을 수 없습니다",
+      "note": "노트를 찾을 수 없습니다"
+    }
+  },
+  "placeholder": {
+    "emptyTagList": "스니펫에 태그를 추가하면 여기에 표시됩니다",
+    "emptyNotesTagList": "노트에 태그를 추가하면 여기에 표시됩니다",
+    "emptyFoldersList": "폴더 없음",
+    "emptySnippetsList": "스니펫 없음",
+    "emptyNotesList": "노트 없음",
+    "searchNotes": "노트 검색...",
+    "emptySheetList": "시트 없음",
+    "emptyDrawingsList": "드로잉 없음",
+    "search": "검색",
+    "searchIn": "{{- context}}에서 검색",
+    "addTag": "태그 추가",
+    "selectLanguage": "언어 선택"
+  },
+  "cloudDownloads": {
+    "downloading": "클라우드 스토리지에서 파일 다운로드 중: {{count}}개 남음",
+    "failed": "클라우드 스토리지에서 파일 다운로드 실패: {{count}}개",
+    "itemPending": "클라우드 스토리지에서 다운로드하는 중…",
+    "label": "클라우드 다운로드"
+  }
+}


### PR DESCRIPTION
## Motivation

This adds Korean (`ko_KR`) translation support — to help Korean-speaking users use this open-source project more comfortably in their own language.

한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.

## Changes

- Register `ko_KR` (`한국어`) in `src/main/i18n/language.ts`, inserted alphabetically between `ja_JP` and `pl_PL`
- Add `src/main/i18n/locales/ko_KR/{ui,menu,messages,preferences,devtools}.json` — 924 keys total, full parity with `en_US`

## Testing

- `node scripts/i18n/check-locale-parity.mjs` — `ko_KR` reports 0 missing keys against `en_US` (all other flagged locales in the output are pre-existing gaps unrelated to this change)
- Verified every `en_US` interpolation placeholder (e.g. `{{count}}`) has a matching placeholder in the corresponding `ko_KR` key, with no mismatches across all 924 keys
- `folderMeta_one`/`_other` and `importedSnippets_one`/`_other` intentionally use identical Korean text: Korean's CLDR plural category set is `{other}` only, so `_one` is never selected at runtime for `ko`, but keeping both keys satisfies the parity checker's key-structure comparison against `en_US`
