### PR TITLE
fix(storage): recover vault watcher lifecycle

### DIFF
--- a/src/main/i18n/locales/en_US/messages.json
+++ b/src/main/i18n/locales/en_US/messages.json
@@ -56,6 +56,7 @@
     "entryNameSnippetConflict": "A snippet with this name already exists in this folder.",
     "entryNameRequestConflict": "A request with this name already exists in this folder.",
     "entryNameFolderConflict": "A folder with this name already exists at this level.",
+    "vaultPathRequired": "Vault path is required.",
     "licenseInvalid": "Invalid license key"
   },
   "description": {

--- a/src/main/i18n/locales/ru_RU/messages.json
+++ b/src/main/i18n/locales/ru_RU/messages.json
@@ -51,6 +51,7 @@
     "entryNameSnippetConflict": "В этой папке уже есть сниппет с таким именем.",
     "entryNameRequestConflict": "В этой папке уже есть запрос с таким именем.",
     "entryNameFolderConflict": "Папка с таким именем уже существует на этом уровне.",
+    "vaultPathRequired": "Укажите путь к хранилищу.",
     "licenseInvalid": "Недействительный лицензионный ключ"
   },
   "description": {

--- a/src/main/ipc/handlers/__tests__/system.test.ts
+++ b/src/main/ipc/handlers/__tests__/system.test.ts
@@ -12,6 +12,8 @@ const openExternal = vi.fn()
 const showItemInFolder = vi.fn()
 const getDirectoryState = vi.fn()
 const moveVault = vi.fn()
+const startMarkdownWatcher = vi.fn()
+const stopMarkdownWatcher = vi.fn()
 const getVaultPath = vi.fn(() => '/current-vault')
 const getPaths = vi.fn((vaultPath: string) => ({ vaultPath }))
 interface SnippetFileLookup {
@@ -23,6 +25,9 @@ const getRuntimeCache = vi.fn((): { snippets: SnippetFileLookup[] } => ({
   snippets: [],
 }))
 const findSnippetById = vi.fn()
+const i18nT = vi.fn()
+const log = vi.fn()
+const preferencesGet = vi.fn()
 const preferencesSet = vi.fn()
 
 vi.mock('electron', () => ({
@@ -58,6 +63,21 @@ vi.mock('../../../currencyRates', () => ({
   refreshFiatRatesForced: vi.fn(),
 }))
 
+vi.mock('../../../i18n', () => ({
+  default: {
+    t: i18nT,
+  },
+}))
+
+vi.mock('../../../utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../utils')>()
+
+  return {
+    ...actual,
+    log,
+  }
+})
+
 vi.mock('../../../storage/providers/markdown/notes/runtime', () => ({
   findNoteById: vi.fn(),
   getNotesFolderPathById: vi.fn(),
@@ -80,11 +100,16 @@ vi.mock('../../../storage/providers/markdown/runtime/paths', () => ({
   getVaultPath,
 }))
 
+vi.mock('../../../storage/providers/markdown/watcher', () => ({
+  startMarkdownWatcher,
+  stopMarkdownWatcher,
+}))
+
 vi.mock('../../../store', () => ({
   store: {
     preferences: {
       // Транзитивный импорт i18n читает локаль при инициализации модуля.
-      get: vi.fn(),
+      get: preferencesGet,
       set: preferencesSet,
     },
   },
@@ -93,6 +118,16 @@ vi.mock('../../../store', () => ({
 beforeEach(() => {
   registeredHandlers.clear()
   vi.clearAllMocks()
+  moveVault.mockReset()
+  startMarkdownWatcher.mockReset()
+  i18nT.mockReset()
+  log.mockReset()
+  preferencesGet.mockReset()
+  preferencesSet.mockReset()
+  preferencesGet.mockImplementation((key: string) =>
+    key === 'storage.vaultPath' ? '/current-vault' : undefined,
+  )
+  i18nT.mockImplementation((key: string) => key)
 })
 
 describe('registerSystemHandlers', () => {
@@ -114,6 +149,17 @@ describe('registerSystemHandlers', () => {
 
     expect(handle).toHaveBeenCalledWith(
       'system:move-vault',
+      expect.any(Function),
+    )
+  })
+
+  it('registers a handler for switching the vault path', async () => {
+    const { registerSystemHandlers } = await import('../system')
+
+    registerSystemHandlers()
+
+    expect(handle).toHaveBeenCalledWith(
+      'system:set-vault-path',
       expect.any(Function),
     )
   })
@@ -148,7 +194,157 @@ describe('registerSystemHandlers', () => {
       'storage.vaultPath',
       '/next-vault',
     )
+    expect(stopMarkdownWatcher).toHaveBeenCalledTimes(1)
+    expect(startMarkdownWatcher).toHaveBeenCalledTimes(1)
+    expect(stopMarkdownWatcher.mock.invocationCallOrder[0]).toBeLessThan(
+      moveVault.mock.invocationCallOrder[0],
+    )
+    expect(moveVault.mock.invocationCallOrder[0]).toBeLessThan(
+      preferencesSet.mock.invocationCallOrder[0],
+    )
+    expect(preferencesSet.mock.invocationCallOrder[0]).toBeLessThan(
+      startMarkdownWatcher.mock.invocationCallOrder[0],
+    )
     expect(result).toEqual({ vaultPath: '/next-vault' })
+  })
+
+  it('switches the configured vault between watcher stop and restart', async () => {
+    const { registerSystemHandlers } = await import('../system')
+
+    registerSystemHandlers()
+
+    const result = registeredHandlers.get('system:set-vault-path')?.(
+      undefined,
+      { vaultPath: '/next-vault' },
+    )
+
+    expect(preferencesSet).toHaveBeenCalledWith(
+      'storage.vaultPath',
+      '/next-vault',
+    )
+    expect(stopMarkdownWatcher).toHaveBeenCalledTimes(1)
+    expect(startMarkdownWatcher).toHaveBeenCalledTimes(1)
+    expect(stopMarkdownWatcher.mock.invocationCallOrder[0]).toBeLessThan(
+      preferencesSet.mock.invocationCallOrder[0],
+    )
+    expect(preferencesSet.mock.invocationCallOrder[0]).toBeLessThan(
+      startMarkdownWatcher.mock.invocationCallOrder[0],
+    )
+    expect(result).toEqual({ vaultPath: '/next-vault' })
+  })
+
+  it('localizes an invalid vault path without restarting storage', async () => {
+    i18nT.mockReturnValue('Localized vault path required')
+    const { registerSystemHandlers } = await import('../system')
+
+    registerSystemHandlers()
+
+    expect(() =>
+      registeredHandlers.get('system:set-vault-path')?.(undefined, {
+        vaultPath: '   ',
+      }),
+    ).toThrow('Localized vault path required')
+    expect(i18nT).toHaveBeenCalledWith('messages:error.vaultPathRequired')
+    expect(preferencesSet).not.toHaveBeenCalled()
+    expect(stopMarkdownWatcher).not.toHaveBeenCalled()
+    expect(startMarkdownWatcher).not.toHaveBeenCalled()
+  })
+
+  it('restores the previous vault when its watcher cannot start', async () => {
+    startMarkdownWatcher.mockImplementationOnce(() => {
+      throw new Error('watcher failed')
+    })
+    const { registerSystemHandlers } = await import('../system')
+
+    registerSystemHandlers()
+
+    expect(() =>
+      registeredHandlers.get('system:set-vault-path')?.(undefined, {
+        vaultPath: '/next-vault',
+      }),
+    ).toThrow('watcher failed')
+    expect(preferencesSet.mock.calls).toEqual([
+      ['storage.vaultPath', '/next-vault'],
+      ['storage.vaultPath', '/current-vault'],
+    ])
+    expect(stopMarkdownWatcher).toHaveBeenCalledTimes(2)
+    expect(startMarkdownWatcher).toHaveBeenCalledTimes(2)
+  })
+
+  it('preserves the vault switch error when watcher recovery also fails', async () => {
+    const switchError = new Error('new watcher failed')
+    const recoveryError = new Error('old watcher recovery failed')
+    startMarkdownWatcher
+      .mockImplementationOnce(() => {
+        throw switchError
+      })
+      .mockImplementationOnce(() => {
+        throw recoveryError
+      })
+    const { registerSystemHandlers } = await import('../system')
+
+    registerSystemHandlers()
+
+    expect(() =>
+      registeredHandlers.get('system:set-vault-path')?.(undefined, {
+        vaultPath: '/next-vault',
+      }),
+    ).toThrow(switchError)
+    expect(log).toHaveBeenCalledWith(
+      'storage:markdown:vault-switch-recovery',
+      recoveryError,
+    )
+  })
+
+  it('retries the target watcher after a successful vault move', async () => {
+    startMarkdownWatcher.mockImplementationOnce(() => {
+      throw new Error('first target watcher start failed')
+    })
+    const { registerSystemHandlers } = await import('../system')
+
+    registerSystemHandlers()
+
+    const result = registeredHandlers.get('system:move-vault')?.(undefined, {
+      targetPath: '/next-vault',
+    })
+
+    expect(result).toEqual({ vaultPath: '/next-vault' })
+    expect(preferencesSet).toHaveBeenCalledWith(
+      'storage.vaultPath',
+      '/next-vault',
+    )
+    expect(stopMarkdownWatcher).toHaveBeenCalledTimes(2)
+    expect(startMarkdownWatcher).toHaveBeenCalledTimes(2)
+    expect(log).not.toHaveBeenCalled()
+  })
+
+  it('preserves the target watcher error when its retry also fails', async () => {
+    const startError = new Error('target watcher failed')
+    const recoveryError = new Error('target watcher recovery failed')
+    startMarkdownWatcher
+      .mockImplementationOnce(() => {
+        throw startError
+      })
+      .mockImplementationOnce(() => {
+        throw recoveryError
+      })
+    const { registerSystemHandlers } = await import('../system')
+
+    registerSystemHandlers()
+
+    expect(() =>
+      registeredHandlers.get('system:move-vault')?.(undefined, {
+        targetPath: '/next-vault',
+      }),
+    ).toThrow(startError)
+    expect(preferencesSet).toHaveBeenCalledWith(
+      'storage.vaultPath',
+      '/next-vault',
+    )
+    expect(log).toHaveBeenCalledWith(
+      'storage:markdown:vault-move-watcher-recovery',
+      recoveryError,
+    )
   })
 
   it('does not update the configured path when moving the vault fails', async () => {
@@ -165,6 +361,38 @@ describe('registerSystemHandlers', () => {
       }),
     ).toThrow('move failed')
     expect(preferencesSet).not.toHaveBeenCalled()
+    expect(stopMarkdownWatcher).toHaveBeenCalledTimes(1)
+    expect(startMarkdownWatcher).toHaveBeenCalledTimes(1)
+    expect(stopMarkdownWatcher.mock.invocationCallOrder[0]).toBeLessThan(
+      moveVault.mock.invocationCallOrder[0],
+    )
+    expect(moveVault.mock.invocationCallOrder[0]).toBeLessThan(
+      startMarkdownWatcher.mock.invocationCallOrder[0],
+    )
+  })
+
+  it('preserves a move error when restoring the old watcher also fails', async () => {
+    const moveError = new Error('move failed')
+    const recoveryError = new Error('old watcher recovery failed')
+    moveVault.mockImplementation(() => {
+      throw moveError
+    })
+    startMarkdownWatcher.mockImplementation(() => {
+      throw recoveryError
+    })
+    const { registerSystemHandlers } = await import('../system')
+
+    registerSystemHandlers()
+
+    expect(() =>
+      registeredHandlers.get('system:move-vault')?.(undefined, {
+        targetPath: '/next-vault',
+      }),
+    ).toThrow(moveError)
+    expect(log).toHaveBeenCalledWith(
+      'storage:markdown:vault-move-recovery',
+      recoveryError,
+    )
   })
 
   it('reveals a snippet file in the file manager', async () => {

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -9,6 +9,7 @@ import {
   refreshCryptoRatesForced,
   refreshFiatRatesForced,
 } from '../../currencyRates'
+import i18n from '../../i18n'
 import { activateLicense } from '../../license'
 import { getCloudDownloadStatus } from '../../storage/providers/markdown/cloudDownloads'
 import {
@@ -31,8 +32,87 @@ import {
   moveVault,
 } from '../../storage/providers/markdown/runtime/moveVault'
 import { getVaultPath } from '../../storage/providers/markdown/runtime/paths'
+import {
+  startMarkdownWatcher,
+  stopMarkdownWatcher,
+} from '../../storage/providers/markdown/watcher'
 import { store } from '../../store'
 import { installDownloadedUpdate } from '../../updates'
+import { log } from '../../utils'
+
+function setVaultPathAndRestartWatcher(vaultPath: string): void {
+  const previousVaultPath = store.preferences.get('storage.vaultPath') as
+    | string
+    | null
+    | undefined
+
+  // Сначала останавливаем watcher: pending-записи flush'ятся в текущий vault,
+  // а cloud callbacks больше не используют захваченные пути старого vault.
+  stopMarkdownWatcher()
+
+  try {
+    store.preferences.set('storage.vaultPath', vaultPath)
+    startMarkdownWatcher()
+  }
+  catch (error) {
+    // Не оставляем приложение на частично запущенном watcher нового vault:
+    // возвращаем прежнюю настройку и восстанавливаем старый watcher.
+    try {
+      stopMarkdownWatcher()
+      store.preferences.set('storage.vaultPath', previousVaultPath ?? null)
+      startMarkdownWatcher()
+    }
+    catch (recoveryError) {
+      log('storage:markdown:vault-switch-recovery', recoveryError)
+    }
+
+    throw error
+  }
+}
+
+function moveVaultAndRestartWatcher(
+  sourcePath: string,
+  targetPath: string,
+): void {
+  // Flush обязан произойти до физического переноса, иначе отложенная запись
+  // способна заново создать state-файл в старом каталоге.
+  stopMarkdownWatcher()
+
+  try {
+    moveVault(sourcePath, targetPath)
+  }
+  catch (error) {
+    // Путь в preferences ещё не менялся — возвращаем watcher старого vault.
+    try {
+      startMarkdownWatcher()
+    }
+    catch (recoveryError) {
+      log('storage:markdown:vault-move-recovery', recoveryError)
+    }
+
+    throw error
+  }
+
+  store.preferences.set('storage.vaultPath', targetPath)
+
+  try {
+    startMarkdownWatcher()
+  }
+  catch (error) {
+    // Файлы уже перенесены, поэтому откат пути небезопасен. Чистый повтор
+    // восстанавливает watcher после частично выполненного startup.
+    try {
+      stopMarkdownWatcher()
+      startMarkdownWatcher()
+      return
+    }
+    catch (recoveryError) {
+      log('storage:markdown:vault-move-watcher-recovery', recoveryError)
+    }
+
+    throw error
+  }
+}
 
 export function registerSystemHandlers() {
   ipcMain.handle('system:activate-license', (_, payload: { key: string }) => {
@@ -79,11 +159,23 @@ export function registerSystemHandlers() {
     },
   )
 
+  ipcMain.handle(
+    'system:set-vault-path',
+    (_, payload: { vaultPath: string }) => {
+      if (typeof payload?.vaultPath !== 'string' || !payload.vaultPath.trim()) {
+        throw new Error(i18n.t('messages:error.vaultPathRequired'))
+      }
+
+      setVaultPathAndRestartWatcher(payload.vaultPath)
+
+      return { vaultPath: payload.vaultPath }
+    },
+  )
+
   ipcMain.handle('system:move-vault', (_, payload: { targetPath: string }) => {
     const sourcePath = getVaultPath()
 
-    moveVault(sourcePath, payload.targetPath)
-    store.preferences.set('storage.vaultPath', payload.targetPath)
+    moveVaultAndRestartWatcher(sourcePath, payload.targetPath)
 
     return { vaultPath: payload.targetPath }
   })

--- a/src/main/storage/providers/markdown/__tests__/watcherLifecycle.test.ts
+++ b/src/main/storage/providers/markdown/__tests__/watcherLifecycle.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface CloudDownloadConfiguration {
+  onDownloaded: (absolutePath: string) => void
+  onQueueActivity: () => void
+}
+
+async function flushImmediate(): Promise<void> {
+  await new Promise<void>(resolve => setImmediate(resolve))
+  await Promise.resolve()
+}
+
+async function setup() {
+  vi.resetModules()
+
+  const vaultRootPath = '/vault'
+  const paths = {
+    inboxDirPath: '/vault/code/.masscode/inbox',
+    metaDirPath: '/vault/code/.masscode',
+    statePath: '/vault/code/.masscode/state.json',
+    trashDirPath: '/vault/code/.masscode/trash',
+    vaultPath: '/vault/code',
+  }
+  const notesPaths = {
+    inboxDirPath: '/vault/notes/.masscode/inbox',
+    metaDirPath: '/vault/notes/.masscode',
+    notesRoot: '/vault/notes',
+    statePath: '/vault/notes/.masscode/state.json',
+    trashDirPath: '/vault/notes/.masscode/trash',
+  }
+  const httpPaths = {
+    httpRoot: '/vault/http',
+    statePath: '/vault/http/.state.yaml',
+  }
+  const cloudConfigurations: CloudDownloadConfiguration[] = []
+  const send = vi.fn()
+  const log = vi.fn()
+  const getPaths = vi.fn(() => paths)
+  const getVaultPath = vi.fn(() => vaultRootPath)
+  const ensureStateFile = vi.fn()
+  const syncRuntimeWithDisk = vi.fn()
+  const syncNotesRuntimeWithDisk = vi.fn()
+  const syncHttpRuntimeWithDisk = vi.fn()
+  const resetCloudDownloads = vi.fn()
+  const getPendingCloudPaths = vi.fn(() => ['/vault/.masscode/state.json'])
+  const configureCloudDownloads = vi.fn(
+    (configuration: CloudDownloadConfiguration) => {
+      cloudConfigurations.push(configuration)
+    },
+  )
+  const watcher = {
+    close: vi.fn(),
+    on: vi.fn(),
+  }
+  watcher.on.mockReturnValue(watcher)
+  const watch = vi.fn(() => watcher)
+  const importEsm = vi.fn(async () => ({ watch }))
+
+  vi.doMock('electron', () => ({
+    BrowserWindow: {
+      getAllWindows: () => [{ webContents: { send } }],
+    },
+  }))
+
+  vi.doMock('../../../../utils', () => ({
+    importEsm,
+    log,
+  }))
+
+  vi.doMock('../cloudDownloads', () => ({
+    configureCloudDownloads,
+    getPendingCloudPaths,
+    resetCloudDownloads,
+  }))
+
+  vi.doMock('../drawings', () => ({
+    wasRecentAppDrawingChange: vi.fn(() => false),
+  }))
+
+  vi.doMock('../http', () => ({
+    getHttpPaths: vi.fn(() => httpPaths),
+    peekHttpRuntimeCache: vi.fn(() => null),
+    resetHttpRuntimeCache: vi.fn(),
+    syncHttpRuntimeWithDisk,
+  }))
+
+  vi.doMock('../notes/runtime', () => ({
+    getNotesPaths: vi.fn(() => notesPaths),
+    peekNotesRuntimeCache: vi.fn(() => null),
+    refreshPendingNoteFiles: vi.fn(() => ({ changed: false, remaining: 0 })),
+    resetNotesPathsCache: vi.fn(),
+    resetNotesRuntimeCache: vi.fn(),
+    syncNoteFileWithDisk: vi.fn(),
+    syncNotesRuntimeWithDisk,
+  }))
+
+  vi.doMock('../runtime', () => ({
+    ensureStateFile,
+    getPaths,
+    getVaultPath,
+    peekRuntimeCache: vi.fn(() => null),
+    refreshPendingSnippetFiles: vi.fn(() => ({
+      changed: false,
+      remaining: 0,
+    })),
+    resetPathsCache: vi.fn(),
+    resetRuntimeCache: vi.fn(),
+    syncRuntimeWithDisk,
+    syncSnippetFileWithDisk: vi.fn(),
+  }))
+
+  vi.doMock('../runtime/shared/appChanges', () => ({
+    wasRecentAppFileChange: vi.fn(() => false),
+  }))
+
+  vi.doMock('../runtime/shared/cloudFiles', () => ({
+    getFileAvailability: vi.fn(() => ({
+      exists: true,
+      isCloudPlaceholder: false,
+      stats: null,
+    })),
+  }))
+
+  vi.doMock('../runtime/shared/guardedRead', () => ({
+    isCloudFileNotDownloadedError: (error: unknown) =>
+      error instanceof Error
+      && error.message.startsWith('CLOUD_FILE_NOT_DOWNLOADED'),
+  }))
+
+  const { startMarkdownWatcher, stopMarkdownWatcher } = await import(
+    '../watcher'
+  )
+
+  return {
+    cloudConfigurations,
+    configureCloudDownloads,
+    ensureStateFile,
+    getPaths,
+    getPendingCloudPaths,
+    importEsm,
+    log,
+    paths,
+    send,
+    startMarkdownWatcher,
+    stopMarkdownWatcher,
+    syncHttpRuntimeWithDisk,
+    syncNotesRuntimeWithDisk,
+    syncRuntimeWithDisk,
+    watch,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('markdown watcher cloud bootstrap', () => {
+  it('retries startup after a legacy cloud state file is hydrated', async () => {
+    const context = await setup()
+    context.getPaths
+      .mockImplementationOnce(() => {
+        throw new Error('CLOUD_FILE_NOT_DOWNLOADED: legacy state')
+      })
+      .mockReturnValue(context.paths)
+
+    expect(() => context.startMarkdownWatcher()).not.toThrow()
+
+    const recovery = context.cloudConfigurations[0]
+    expect(recovery).toBeDefined()
+    recovery.onDownloaded('/vault/.masscode/state.json')
+    await flushImmediate()
+
+    expect(context.getPaths).toHaveBeenCalledTimes(2)
+    expect(context.ensureStateFile).toHaveBeenCalledWith(context.paths)
+    expect(context.syncRuntimeWithDisk).toHaveBeenCalledWith(context.paths)
+    expect(context.syncNotesRuntimeWithDisk).toHaveBeenCalledTimes(1)
+    expect(context.syncHttpRuntimeWithDisk).toHaveBeenCalledTimes(1)
+    expect(context.importEsm).toHaveBeenCalledWith('chokidar')
+    expect(context.watch).toHaveBeenCalledWith(
+      '/vault',
+      expect.objectContaining({ ignoreInitial: true, persistent: true }),
+    )
+    expect(context.send).toHaveBeenCalledWith('system:storage-synced')
+  })
+
+  it('keeps waiting when another cloud state file blocks the retry', async () => {
+    const context = await setup()
+    context.getPaths.mockImplementation(() => {
+      throw new Error('CLOUD_FILE_NOT_DOWNLOADED: legacy state')
+    })
+
+    context.startMarkdownWatcher()
+    context.cloudConfigurations[0].onDownloaded('/vault/.masscode/state.json')
+    await flushImmediate()
+
+    expect(context.getPaths).toHaveBeenCalledTimes(2)
+    expect(context.configureCloudDownloads).toHaveBeenCalledTimes(2)
+    expect(context.ensureStateFile).not.toHaveBeenCalled()
+    expect(context.send).not.toHaveBeenCalledWith('system:storage-synced')
+  })
+
+  it('retries once when hydration finished before recovery was configured', async () => {
+    const context = await setup()
+    context.getPendingCloudPaths.mockReturnValue([])
+    context.getPaths
+      .mockImplementationOnce(() => {
+        throw new Error('CLOUD_FILE_NOT_DOWNLOADED: legacy state')
+      })
+      .mockReturnValue(context.paths)
+
+    context.startMarkdownWatcher()
+    await flushImmediate()
+
+    expect(context.getPaths).toHaveBeenCalledTimes(2)
+    expect(context.ensureStateFile).toHaveBeenCalledWith(context.paths)
+    expect(context.send).toHaveBeenCalledWith('system:storage-synced')
+  })
+
+  it('ignores a hydration callback after watcher shutdown', async () => {
+    const context = await setup()
+    context.getPaths.mockImplementationOnce(() => {
+      throw new Error('CLOUD_FILE_NOT_DOWNLOADED: legacy state')
+    })
+
+    context.startMarkdownWatcher()
+    const recovery = context.cloudConfigurations[0]
+    context.stopMarkdownWatcher()
+    recovery.onDownloaded('/vault/.masscode/state.json')
+    await flushImmediate()
+
+    expect(context.getPaths).toHaveBeenCalledTimes(1)
+    expect(context.send).not.toHaveBeenCalledWith('system:storage-synced')
+  })
+
+  it('still propagates non-cloud startup errors', async () => {
+    const context = await setup()
+    context.getPaths.mockImplementationOnce(() => {
+      throw new Error('EACCES')
+    })
+
+    expect(() => context.startMarkdownWatcher()).toThrow('EACCES')
+    expect(context.configureCloudDownloads).not.toHaveBeenCalled()
+    expect(context.log).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/storage/providers/markdown/cloudDownloads.ts
+++ b/src/main/storage/providers/markdown/cloudDownloads.ts
@@ -133,6 +133,7 @@ export function resetCloudDownloads(): void {
   onFileDownloaded = null
   onQueueActivity = null
   resetCloudFileExemptions()
+  broadcastStatus()
 }
 
 export function enqueueCloudDownload(absolutePath: string): void {

--- a/src/main/storage/providers/markdown/runtime/__tests__/paths.test.ts
+++ b/src/main/storage/providers/markdown/runtime/__tests__/paths.test.ts
@@ -2,7 +2,9 @@ import os from 'node:os'
 import path from 'node:path'
 import fs from 'fs-extra'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getPaths, hasMarkdownVaultData } from '../paths'
+import { enqueueCloudDownload } from '../../cloudDownloads'
+import { getPaths, hasMarkdownVaultData, resetPathsCache } from '../paths'
+import { setDatalessProbeForTests } from '../shared/cloudFiles'
 
 vi.mock('electron-store', () => {
   class MockStore {
@@ -62,6 +64,10 @@ vi.mock('../../../../../store', () => ({
   },
 }))
 
+vi.mock('../../cloudDownloads', () => ({
+  enqueueCloudDownload: vi.fn(),
+}))
+
 const tempDirs: string[] = []
 
 function createTempDir(): string {
@@ -70,7 +76,23 @@ function createTempDir(): string {
   return tempDir
 }
 
+function makeSparsePlaceholder(absolutePath: string, size = 4096): void {
+  fs.removeSync(absolutePath)
+  const fd = fs.openSync(absolutePath, 'w')
+  fs.ftruncateSync(fd, size)
+  fs.closeSync(fd)
+}
+
+function hasPlaceholderSignature(absolutePath: string): boolean {
+  const stats = fs.statSync(absolutePath)
+  return stats.size > 0 && stats.blocks === 0
+}
+
 afterEach(() => {
+  setDatalessProbeForTests(null)
+  resetPathsCache()
+  vi.mocked(enqueueCloudDownload).mockClear()
+
   while (tempDirs.length > 0) {
     const tempDir = tempDirs.pop()
     if (tempDir) {
@@ -80,6 +102,59 @@ afterEach(() => {
 })
 
 describe('getPaths', () => {
+  it('retries legacy layout migration after cloud state hydration', () => {
+    const vaultPath = createTempDir()
+    const legacyStatePath = path.join(vaultPath, '.masscode', 'state.json')
+    const legacyState = {
+      counters: {
+        contentId: 0,
+        folderId: 1,
+        snippetId: 1,
+        tagId: 0,
+      },
+      folders: [
+        {
+          id: 1,
+          name: 'Cloud',
+          orderIndex: 0,
+          parentId: null,
+        },
+      ],
+      snippets: [
+        {
+          filePath: 'Cloud/demo.md',
+          id: 1,
+        },
+      ],
+      tags: [],
+      version: 2,
+    }
+
+    fs.ensureDirSync(path.dirname(legacyStatePath))
+    fs.writeJSONSync(legacyStatePath, legacyState)
+    fs.ensureDirSync(path.join(vaultPath, 'Cloud'))
+    fs.writeFileSync(path.join(vaultPath, 'Cloud', 'demo.md'), '# Cloud')
+    makeSparsePlaceholder(legacyStatePath)
+    if (!hasPlaceholderSignature(legacyStatePath)) {
+      return
+    }
+    setDatalessProbeForTests(() => true)
+
+    expect(() => getPaths(vaultPath)).toThrow(/CLOUD_FILE_NOT_DOWNLOADED/)
+    expect(enqueueCloudDownload).toHaveBeenCalledWith(legacyStatePath)
+    expect(fs.pathExistsSync(path.join(vaultPath, 'code'))).toBe(false)
+
+    fs.writeJSONSync(legacyStatePath, legacyState)
+
+    const paths = getPaths(vaultPath)
+
+    expect(paths.vaultPath).toBe(path.join(vaultPath, 'code'))
+    expect(
+      fs.pathExistsSync(path.join(paths.vaultPath, 'Cloud', 'demo.md')),
+    ).toBe(true)
+    expect(fs.pathExistsSync(path.join(vaultPath, '.masscode'))).toBe(false)
+  })
+
   it('detects existing data in legacy root vault layout', () => {
     const vaultPath = createTempDir()
 

--- a/src/main/storage/providers/markdown/watcher.ts
+++ b/src/main/storage/providers/markdown/watcher.ts
@@ -1,7 +1,6 @@
 import type { ChokidarOptions, FSWatcher } from 'chokidar'
 import type { NotesPaths, NotesRuntimeCache } from './notes/runtime'
 import path from 'node:path'
-import { BrowserWindow } from 'electron'
 import { importEsm, log } from '../../../utils'
 import {
   configureCloudDownloads,
@@ -40,6 +39,8 @@ import {
 } from './runtime'
 import { wasRecentAppFileChange } from './runtime/shared/appChanges'
 import { getFileAvailability } from './runtime/shared/cloudFiles'
+import { isCloudFileNotDownloadedError } from './runtime/shared/guardedRead'
+import { broadcastStorageSynced } from './runtime/shared/vaultReconcile'
 import {
   getWatchPathSpaceId,
   isCodeWatchPath,
@@ -319,9 +320,7 @@ function scheduleStateSync(
         || hasHttpChanges
         || hasDrawingsChanges
       ) {
-        BrowserWindow.getAllWindows().forEach((window) => {
-          window.webContents.send('system:storage-synced')
-        })
+        broadcastStorageSynced()
       }
     }
     catch (error) {
@@ -394,9 +393,7 @@ function scheduleCloudRefresh(
     }
 
     if (changed) {
-      BrowserWindow.getAllWindows().forEach((window) => {
-        window.webContents.send('system:storage-synced')
-      })
+      broadcastStorageSynced()
     }
 
     if (remaining > 0) {
@@ -441,8 +438,7 @@ export function stopMarkdownWatcher(): void {
   resetNotesPathsCache()
 }
 
-export function startMarkdownWatcher(): void {
-  const vaultRootPath = getVaultPath()
+function initializeMarkdownWatcher(vaultRootPath: string): void {
   const paths = getPaths(vaultRootPath)
   const runtimeCache = peekRuntimeCache()
   const notesPaths = getNotesPaths(vaultRootPath)
@@ -594,4 +590,70 @@ export function startMarkdownWatcher(): void {
 
       log('storage:markdown:watcher-start', error)
     })
+}
+
+function configureCloudBootstrapRecovery(vaultRootPath: string): void {
+  const expectedStartToken = watcherStartToken
+  let isRetryScheduled = false
+
+  const scheduleRetry = (): void => {
+    if (isRetryScheduled) {
+      return
+    }
+
+    isRetryScheduled = true
+    setImmediate(() => {
+      isRetryScheduled = false
+
+      if (
+        watcherStartToken !== expectedStartToken
+        || getVaultPath() !== vaultRootPath
+      ) {
+        return
+      }
+
+      try {
+        if (tryStartMarkdownWatcher(vaultRootPath)) {
+          broadcastStorageSynced()
+        }
+      }
+      catch (error) {
+        log('storage:markdown:watcher-hydration-retry', error)
+      }
+    })
+  }
+
+  configureCloudDownloads({
+    onDownloaded: scheduleRetry,
+    onQueueActivity: () => {},
+  })
+
+  // Файл мог материализоваться между первым stat и постановкой callback.
+  // Если очередь уже пуста, один отложенный retry закрывает это окно без
+  // polling-loop во время обычной активной загрузки.
+  if (getPendingCloudPaths().length === 0) {
+    scheduleRetry()
+  }
+}
+
+function tryStartMarkdownWatcher(vaultRootPath: string): boolean {
+  try {
+    initializeMarkdownWatcher(vaultRootPath)
+    return true
+  }
+  catch (error) {
+    if (!isCloudFileNotDownloadedError(error)) {
+      throw error
+    }
+
+    // Разрешение legacy-layout может найти offloaded state до регистрации
+    // обычных watcher callbacks. Сохраняем загрузку и повторяем startup,
+    // когда облачный провайдер материализует файл.
+    configureCloudBootstrapRecovery(vaultRootPath)
+    return false
+  }
+}
+
+export function startMarkdownWatcher(): void {
+  tryStartMarkdownWatcher(getVaultPath())
 }

--- a/src/main/types/ipc.ts
+++ b/src/main/types/ipc.ts
@@ -50,6 +50,7 @@ type SystemAction =
   | 'get-directory-state'
   | 'reload'
   | 'move-vault'
+  | 'set-vault-path'
   | 'open-external'
   | 'show-http-request-in-file-manager'
   | 'show-notes-folder-in-file-manager'

--- a/src/renderer/components/preferences/Storage.vue
+++ b/src/renderer/components/preferences/Storage.vue
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/shadcn/badge'
 import { Button } from '@/components/ui/shadcn/button'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/shadcn/radio-group'
 import {
+  resetCodeSpaceInitialization,
   resetHttpSpaceState,
   resetNotesSpaceInitialization,
   useDialog,
@@ -34,7 +35,7 @@ interface DirectoryStateResponse {
   isEmpty: boolean
 }
 
-interface MoveVaultResponse {
+interface VaultPathResponse {
   vaultPath: string
 }
 
@@ -185,6 +186,7 @@ async function getSnippetsCounts() {
 getSnippetsCounts()
 
 async function resetAndReloadVaultData() {
+  resetCodeSpaceInitialization()
   resetMathNotebook()
   resetDrawings()
   clearNotesState()
@@ -207,32 +209,56 @@ async function resetAndReloadVaultData() {
   await getSnippetsCounts()
 }
 
+async function syncVaultPathAfterFailedChange() {
+  // Main process мог сохранить новый путь до ошибки следующего шага
+  // (например, запуска watcher после физического переноса). UI должен
+  // отражать фактически активный vault, а не уже несуществующий старый.
+  const configuredVaultPath = store.preferences.get<string | null>(
+    'storage.vaultPath',
+  )
+  if (configuredVaultPath !== vaultPath.value) {
+    vaultPath.value = configuredVaultPath
+    await resetAndReloadVaultData()
+  }
+}
+
 async function openVaultStorage() {
   if (isMovingVault.value) {
     return
   }
 
-  const result = await ipc.invoke<DialogOptions, string>(
+  const selectedPath = await ipc.invoke<DialogOptions, string>(
     'main-menu:open-dialog',
     {
       properties: ['openDirectory', 'createDirectory'],
     },
   )
 
-  if (!result) {
+  if (!selectedPath) {
     return
   }
 
-  vaultPath.value = result
-  store.preferences.set('storage.vaultPath', result)
-  await resetAndReloadVaultData()
+  try {
+    const result = await ipc.invoke<{ vaultPath: string }, VaultPathResponse>(
+      'system:set-vault-path',
+      { vaultPath: selectedPath },
+    )
 
-  sonner({
-    message: i18n.t('messages:success.vaultLoaded'),
-    type: 'success',
-  })
+    vaultPath.value = result.vaultPath
+    await resetAndReloadVaultData()
 
-  await refreshVaultDoctorAfterVaultChange()
+    sonner({
+      message: i18n.t('messages:success.vaultLoaded'),
+      type: 'success',
+    })
+
+    await refreshVaultDoctorAfterVaultChange()
+  }
+  catch (err) {
+    await syncVaultPathAfterFailedChange()
+    const error = err as Error
+    sonner({ message: error.message, type: 'error' })
+  }
 }
 
 async function moveVaultStorage() {
@@ -272,7 +298,7 @@ async function moveVaultStorage() {
   isMovingVault.value = true
 
   try {
-    const result = await ipc.invoke<{ targetPath: string }, MoveVaultResponse>(
+    const result = await ipc.invoke<{ targetPath: string }, VaultPathResponse>(
       'system:move-vault',
       { targetPath },
     )
@@ -290,6 +316,7 @@ async function moveVaultStorage() {
     })
   }
   catch (err) {
+    await syncVaultPathAfterFailedChange()
     const error = err as Error
     sonner({ message: error.message, type: 'error' })
   }

--- a/src/renderer/composables/__tests__/useCodeSpaceInit.test.ts
+++ b/src/renderer/composables/__tests__/useCodeSpaceInit.test.ts
@@ -49,13 +49,16 @@ async function setup() {
     normalizeCodeSelectionState,
   }))
 
-  const { initCodeSpace } = await import('../useCodeSpaceInit')
+  const { initCodeSpace, resetCodeSpaceInitialization } = await import(
+    '../useCodeSpaceInit'
+  )
 
   return {
     callOrder,
     initCodeSpace,
     isCodeSpaceInitialized,
     normalizeCodeSelectionState,
+    resetCodeSpaceInitialization,
   }
 }
 
@@ -64,6 +67,24 @@ beforeEach(() => {
 })
 
 describe('initCodeSpace', () => {
+  it('invalidates initialization before loading another vault', async () => {
+    const context = await setup()
+    context.isCodeSpaceInitialized.value = true
+
+    context.resetCodeSpaceInitialization()
+
+    expect(context.isCodeSpaceInitialized.value).toBe(false)
+
+    await context.initCodeSpace()
+
+    expect(context.callOrder).toEqual([
+      'getFolders',
+      'getTags',
+      'normalizeCodeSelectionState',
+    ])
+    expect(context.isCodeSpaceInitialized.value).toBe(true)
+  })
+
   it('loads folders and tags before normalizing selection state', async () => {
     const context = await setup()
 

--- a/src/renderer/composables/useCodeSpaceInit.ts
+++ b/src/renderer/composables/useCodeSpaceInit.ts
@@ -7,6 +7,10 @@ const { isCodeSpaceInitialized } = useApp()
 const { getFolders } = useFolders()
 const { getTags } = useTags()
 
+export function resetCodeSpaceInitialization(): void {
+  isCodeSpaceInitialized.value = false
+}
+
 export async function initCodeSpace(): Promise<void> {
   const results = await Promise.allSettled([getFolders(), getTags()])
 


### PR DESCRIPTION
Restarts the markdown watcher when the vault changes, resumes cloud vault initialization after hydration, and reloads renderer space state. Validation: 37 targeted tests and the main TypeScript check passed.