### PR TITLE
feat(macos): add configurable Dock badge counter

### DIFF
--- a/src/main/dockBadge/__tests__/counts.test.ts
+++ b/src/main/dockBadge/__tests__/counts.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+import { countDockBadge, getLocalDateOnly, isValidDateOnly } from '../counts'
+
+const emptyInput = { notes: [], snippets: [] }
+
+describe('dock badge counts', () => {
+  it('counts only active Code Inbox snippets', () => {
+    expect(
+      countDockBadge(
+        'codeInbox',
+        {
+          notes: [],
+          snippets: [
+            { folderId: null, isDeleted: 0 },
+            { folderId: 1, isDeleted: 0 },
+            { folderId: null, isDeleted: 1 },
+          ],
+        },
+        '2026-07-12',
+      ),
+    ).toBe(1)
+  })
+
+  it('counts all active Notes Inbox notes including tasks', () => {
+    expect(
+      countDockBadge(
+        'notesInbox',
+        {
+          notes: [
+            { folderId: null, isDeleted: 0, properties: {} },
+            {
+              folderId: null,
+              isDeleted: 0,
+              properties: { type: 'task' },
+            },
+            { folderId: 1, isDeleted: 0, properties: {} },
+            { folderId: null, isDeleted: 1, properties: {} },
+          ],
+          snippets: [],
+        },
+        '2026-07-12',
+      ),
+    ).toBe(2)
+  })
+
+  it('counts incomplete overdue and today tasks', () => {
+    expect(
+      countDockBadge(
+        'tasksDue',
+        {
+          notes: [
+            {
+              folderId: null,
+              isDeleted: 0,
+              properties: { type: 'task', status: 'todo', due: '2026-07-11' },
+            },
+            {
+              folderId: 1,
+              isDeleted: 0,
+              properties: {
+                type: 'task',
+                status: 'inProgress',
+                due: '2026-07-12',
+              },
+            },
+            {
+              folderId: 1,
+              isDeleted: 0,
+              properties: {
+                type: 'task',
+                status: 'blocked',
+                due: '2026-07-12',
+              },
+            },
+            {
+              folderId: 1,
+              isDeleted: 0,
+              properties: { type: 'task', due: '2026-07-12' },
+            },
+            {
+              folderId: 1,
+              isDeleted: 0,
+              properties: {
+                type: 'task',
+                status: 'unknown',
+                due: '2026-07-12',
+              },
+            },
+          ],
+          snippets: [],
+        },
+        '2026-07-12',
+      ),
+    ).toBe(5)
+  })
+
+  it('excludes completed, future, undated, invalid, deleted and normal notes', () => {
+    expect(
+      countDockBadge(
+        'tasksDue',
+        {
+          notes: [
+            {
+              folderId: null,
+              isDeleted: 0,
+              properties: { type: 'task', status: 'done', due: '2026-07-12' },
+            },
+            {
+              folderId: null,
+              isDeleted: 0,
+              properties: { type: 'task', due: '2026-07-13' },
+            },
+            { folderId: null, isDeleted: 0, properties: { type: 'task' } },
+            {
+              folderId: null,
+              isDeleted: 0,
+              properties: { type: 'task', due: '2026-02-30' },
+            },
+            {
+              folderId: null,
+              isDeleted: 1,
+              properties: { type: 'task', due: '2026-07-12' },
+            },
+            {
+              folderId: null,
+              isDeleted: 0,
+              properties: { type: 'note', due: '2026-07-12' },
+            },
+          ],
+          snippets: [],
+        },
+        '2026-07-12',
+      ),
+    ).toBe(0)
+  })
+
+  it('returns zero for none', () => {
+    expect(countDockBadge('none', emptyInput, '2026-07-12')).toBe(0)
+  })
+})
+
+describe('date-only helpers', () => {
+  it('accepts only strict real calendar dates', () => {
+    expect(isValidDateOnly('2024-02-29')).toBe(true)
+    expect(isValidDateOnly('2026-02-29')).toBe(false)
+    expect(isValidDateOnly('2026-2-03')).toBe(false)
+    expect(isValidDateOnly('2026-02-03T00:00:00Z')).toBe(false)
+  })
+
+  it('formats a date using local calendar fields', () => {
+    expect(getLocalDateOnly(new Date(2026, 6, 12, 23, 59))).toBe('2026-07-12')
+  })
+})

--- a/src/main/dockBadge/__tests__/index.test.ts
+++ b/src/main/dockBadge/__tests__/index.test.ts
@@ -1,0 +1,133 @@
+import type { DockBadgeSource } from '../../store/types'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createDockBadgeController } from '../index'
+
+vi.mock('electron', () => ({
+  app: {
+    isReady: vi.fn(() => true),
+    setBadgeCount: vi.fn(),
+  },
+}))
+
+vi.mock('../../store', () => ({
+  store: {
+    preferences: {
+      get: vi.fn(() => 'none'),
+    },
+  },
+}))
+
+vi.mock('../../storage/providers/markdown/notes/runtime/constants', () => ({
+  peekNotesRuntimeCache: vi.fn(() => null),
+}))
+
+vi.mock('../../storage/providers/markdown/runtime/cache', () => ({
+  peekRuntimeCache: vi.fn(() => null),
+}))
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function createContext(source: DockBadgeSource = 'none') {
+  const setBadgeCount = vi.fn()
+  const peekNotesCache = vi.fn(() => null)
+  const peekSnippetsCache = vi.fn(() => null)
+  let currentSource = source
+
+  const controller = createDockBadgeController({
+    app: { isReady: () => true, setBadgeCount },
+    clearTimer: clearTimeout,
+    getSource: () => currentSource,
+    now: () => new Date(),
+    peekNotesCache,
+    peekSnippetsCache,
+    platform: 'darwin',
+    setTimer: setTimeout,
+  })
+
+  return {
+    controller,
+    peekNotesCache,
+    peekSnippetsCache,
+    setBadgeCount,
+    setSource: (value: DockBadgeSource) => {
+      currentSource = value
+    },
+  }
+}
+
+describe('dock badge controller', () => {
+  it('refreshes immediately from only the selected cache', () => {
+    const context = createContext('codeInbox')
+    context.peekSnippetsCache.mockReturnValue({
+      snippets: [{ folderId: null, isDeleted: 0 }],
+    } as any)
+
+    expect(context.controller.refresh()).toBe(1)
+    expect(context.setBadgeCount).toHaveBeenCalledWith(1)
+    expect(context.peekSnippetsCache).toHaveBeenCalledTimes(1)
+    expect(context.peekNotesCache).not.toHaveBeenCalled()
+  })
+
+  it('does not touch Electron before readiness or outside macOS', () => {
+    const setBadgeCount = vi.fn()
+    const base = {
+      app: { isReady: () => false, setBadgeCount },
+      clearTimer: clearTimeout,
+      getSource: () => 'none' as const,
+      now: () => new Date(),
+      peekNotesCache: () => null,
+      peekSnippetsCache: () => null,
+      setTimer: setTimeout,
+    }
+
+    expect(
+      createDockBadgeController({ ...base, platform: 'darwin' }).refresh(),
+    ).toBe(0)
+    expect(
+      createDockBadgeController({ ...base, platform: 'linux' }).refresh(),
+    ).toBe(0)
+    expect(setBadgeCount).not.toHaveBeenCalled()
+  })
+
+  it('debounces scheduled refreshes', () => {
+    vi.useFakeTimers()
+    const context = createContext('none')
+
+    context.controller.scheduleRefresh()
+    context.controller.scheduleRefresh()
+    vi.advanceTimersByTime(149)
+    expect(context.setBadgeCount).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(context.setBadgeCount).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes tasks at each next local midnight', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 6, 12, 23, 59, 59, 900))
+    const context = createContext('tasksDue')
+
+    context.controller.refresh()
+    expect(context.setBadgeCount).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(100)
+    expect(context.setBadgeCount).toHaveBeenCalledTimes(2)
+
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000)
+    expect(context.setBadgeCount).toHaveBeenCalledTimes(3)
+  })
+
+  it('clears timers and badge during cleanup', () => {
+    vi.useFakeTimers()
+    const context = createContext('tasksDue')
+    context.controller.refresh()
+    context.controller.scheduleRefresh()
+
+    context.controller.cleanup()
+    vi.runAllTimers()
+
+    expect(context.setBadgeCount.mock.calls).toEqual([[0], [0]])
+  })
+})

--- a/src/main/dockBadge/__tests__/index.test.ts
+++ b/src/main/dockBadge/__tests__/index.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
 })
 
 function createContext(source: DockBadgeSource = 'none') {
-  const setBadgeCount = vi.fn()
+  const setBadgeCount = vi.fn(() => true)
   const peekNotesCache = vi.fn(() => null)
   const peekSnippetsCache = vi.fn(() => null)
   let currentSource = source
@@ -64,10 +64,20 @@ describe('dock badge controller', () => {
       snippets: [{ folderId: null, isDeleted: 0 }],
     } as any)
 
-    expect(context.controller.refresh()).toBe(1)
+    expect(context.controller.refresh()).toEqual({ applied: true, count: 1 })
     expect(context.setBadgeCount).toHaveBeenCalledWith(1)
     expect(context.peekSnippetsCache).toHaveBeenCalledTimes(1)
     expect(context.peekNotesCache).not.toHaveBeenCalled()
+  })
+
+  it('reports when macOS rejects the badge update', () => {
+    const context = createContext('notesInbox')
+    context.setBadgeCount.mockReturnValue(false)
+
+    expect(context.controller.refresh()).toEqual({
+      applied: false,
+      count: 0,
+    })
   })
 
   it('does not touch Electron before readiness or outside macOS', () => {
@@ -84,10 +94,10 @@ describe('dock badge controller', () => {
 
     expect(
       createDockBadgeController({ ...base, platform: 'darwin' }).refresh(),
-    ).toBe(0)
+    ).toEqual({ applied: false, count: 0 })
     expect(
       createDockBadgeController({ ...base, platform: 'linux' }).refresh(),
-    ).toBe(0)
+    ).toEqual({ applied: false, count: 0 })
     expect(setBadgeCount).not.toHaveBeenCalled()
   })
 

--- a/src/main/dockBadge/counts.ts
+++ b/src/main/dockBadge/counts.ts
@@ -1,0 +1,81 @@
+import type { DockBadgeSource } from '../store/types'
+
+interface BadgeSnippet {
+  folderId: number | null
+  isDeleted: number
+}
+
+interface BadgeNote extends BadgeSnippet {
+  properties: Record<string, unknown>
+}
+
+export interface DockBadgeCountsInput {
+  notes: BadgeNote[]
+  snippets: BadgeSnippet[]
+}
+
+const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/
+
+export function getLocalDateOnly(date: Date): string {
+  const year = String(date.getFullYear()).padStart(4, '0')
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${year}-${month}-${day}`
+}
+
+export function isValidDateOnly(value: unknown): value is string {
+  if (typeof value !== 'string') {
+    return false
+  }
+
+  const match = DATE_ONLY_RE.exec(value)
+  if (!match) {
+    return false
+  }
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const date = new Date(year, month - 1, day)
+
+  return (
+    date.getFullYear() === year
+    && date.getMonth() === month - 1
+    && date.getDate() === day
+  )
+}
+
+export function countDockBadge(
+  source: DockBadgeSource,
+  input: DockBadgeCountsInput,
+  localToday: string,
+): number {
+  if (source === 'none') {
+    return 0
+  }
+
+  if (source === 'codeInbox') {
+    return input.snippets.filter(
+      snippet => snippet.folderId === null && snippet.isDeleted === 0,
+    ).length
+  }
+
+  if (source === 'notesInbox') {
+    return input.notes.filter(
+      note => note.folderId === null && note.isDeleted === 0,
+    ).length
+  }
+
+  return input.notes.filter((note) => {
+    const due = note.properties.due
+
+    return (
+      note.isDeleted === 0
+      && note.properties.type === 'task'
+      && note.properties.status !== 'done'
+      && isValidDateOnly(due)
+      && due <= localToday
+    )
+  }).length
+}

--- a/src/main/dockBadge/index.ts
+++ b/src/main/dockBadge/index.ts
@@ -26,8 +26,13 @@ interface DockBadgeControllerDependencies {
 
 export interface DockBadgeController {
   cleanup: () => void
-  refresh: () => number
+  refresh: () => DockBadgeRefreshResult
   scheduleRefresh: () => void
+}
+
+export interface DockBadgeRefreshResult {
+  applied: boolean
+  count: number
 }
 
 export function createDockBadgeController(
@@ -65,11 +70,11 @@ export function createDockBadgeController(
     }, nextMidnight.getTime() - now.getTime())
   }
 
-  function refresh(): number {
+  function refresh(): DockBadgeRefreshResult {
     clearRefreshTimer()
     if (dependencies.platform !== 'darwin' || !dependencies.app.isReady()) {
       clearMidnightTimer()
-      return 0
+      return { applied: false, count: 0 }
     }
 
     const source = dependencies.getSource()
@@ -87,10 +92,10 @@ export function createDockBadgeController(
       getLocalDateOnly(dependencies.now()),
     )
 
-    dependencies.app.setBadgeCount(count)
+    const applied = dependencies.app.setBadgeCount(count)
     scheduleMidnightRefresh(source)
 
-    return count
+    return { applied, count }
   }
 
   function scheduleRefresh(): void {

--- a/src/main/dockBadge/index.ts
+++ b/src/main/dockBadge/index.ts
@@ -1,0 +1,133 @@
+/* eslint-disable node/prefer-global/process */
+import type { NotesRuntimeCache } from '../storage/providers/markdown/notes/runtime/types'
+import type { MarkdownRuntimeCache } from '../storage/providers/markdown/runtime/types'
+import type { DockBadgeSource } from '../store/types'
+import { app } from 'electron'
+import { peekNotesRuntimeCache } from '../storage/providers/markdown/notes/runtime/constants'
+import { peekRuntimeCache } from '../storage/providers/markdown/runtime/cache'
+import { store } from '../store'
+import { countDockBadge, getLocalDateOnly } from './counts'
+
+const REFRESH_DELAY_MS = 150
+
+interface DockBadgeControllerDependencies {
+  app: Pick<typeof app, 'isReady' | 'setBadgeCount'>
+  clearTimer: (timer: ReturnType<typeof setTimeout>) => void
+  getSource: () => DockBadgeSource
+  now: () => Date
+  peekNotesCache: () => NotesRuntimeCache | null
+  peekSnippetsCache: () => MarkdownRuntimeCache | null
+  platform: NodeJS.Platform
+  setTimer: (
+    callback: () => void,
+    delay: number,
+  ) => ReturnType<typeof setTimeout>
+}
+
+export interface DockBadgeController {
+  cleanup: () => void
+  refresh: () => number
+  scheduleRefresh: () => void
+}
+
+export function createDockBadgeController(
+  dependencies: DockBadgeControllerDependencies,
+): DockBadgeController {
+  let refreshTimer: ReturnType<typeof setTimeout> | null = null
+  let midnightTimer: ReturnType<typeof setTimeout> | null = null
+
+  function clearRefreshTimer(): void {
+    if (refreshTimer) {
+      dependencies.clearTimer(refreshTimer)
+      refreshTimer = null
+    }
+  }
+
+  function clearMidnightTimer(): void {
+    if (midnightTimer) {
+      dependencies.clearTimer(midnightTimer)
+      midnightTimer = null
+    }
+  }
+
+  function scheduleMidnightRefresh(source: DockBadgeSource): void {
+    clearMidnightTimer()
+    if (source !== 'tasksDue') {
+      return
+    }
+
+    const now = dependencies.now()
+    const nextMidnight = new Date(now)
+    nextMidnight.setHours(24, 0, 0, 0)
+    midnightTimer = dependencies.setTimer(() => {
+      midnightTimer = null
+      refresh()
+    }, nextMidnight.getTime() - now.getTime())
+  }
+
+  function refresh(): number {
+    clearRefreshTimer()
+    if (dependencies.platform !== 'darwin' || !dependencies.app.isReady()) {
+      clearMidnightTimer()
+      return 0
+    }
+
+    const source = dependencies.getSource()
+    const snippets
+      = source === 'codeInbox'
+        ? (dependencies.peekSnippetsCache()?.snippets ?? [])
+        : []
+    const notes
+      = source === 'notesInbox' || source === 'tasksDue'
+        ? (dependencies.peekNotesCache()?.notes ?? [])
+        : []
+    const count = countDockBadge(
+      source,
+      { notes, snippets },
+      getLocalDateOnly(dependencies.now()),
+    )
+
+    dependencies.app.setBadgeCount(count)
+    scheduleMidnightRefresh(source)
+
+    return count
+  }
+
+  function scheduleRefresh(): void {
+    if (dependencies.platform !== 'darwin') {
+      return
+    }
+
+    clearRefreshTimer()
+    refreshTimer = dependencies.setTimer(() => {
+      refreshTimer = null
+      refresh()
+    }, REFRESH_DELAY_MS)
+  }
+
+  function cleanup(): void {
+    clearRefreshTimer()
+    clearMidnightTimer()
+    if (dependencies.platform === 'darwin' && dependencies.app.isReady()) {
+      dependencies.app.setBadgeCount(0)
+    }
+  }
+
+  return { cleanup, refresh, scheduleRefresh }
+}
+
+const controller = createDockBadgeController({
+  app,
+  clearTimer: clearTimeout,
+  getSource: () =>
+    store.preferences.get('appearance.dockBadgeSource') as DockBadgeSource,
+  now: () => new Date(),
+  peekNotesCache: peekNotesRuntimeCache,
+  peekSnippetsCache: peekRuntimeCache,
+  platform: process.platform,
+  setTimer: setTimeout,
+})
+
+export const cleanupDockBadge = controller.cleanup
+export const refreshDockBadge = controller.refresh
+export const scheduleDockBadgeRefresh = controller.scheduleRefresh

--- a/src/main/i18n/locales/en_US/preferences.json
+++ b/src/main/i18n/locales/en_US/preferences.json
@@ -134,6 +134,13 @@
   },
   "appearance": {
     "label": "Appearance",
+    "dockBadge": {
+      "label": "Dock Icon Counter",
+      "none": "Don't Show",
+      "codeInbox": "Code Inbox",
+      "notesInbox": "Notes Inbox",
+      "tasksDue": "Tasks Due Today"
+    },
     "theme": {
       "label": "Theme",
       "builtIn": "Built-in",

--- a/src/main/i18n/locales/en_US/preferences.json
+++ b/src/main/i18n/locales/en_US/preferences.json
@@ -139,7 +139,8 @@
       "none": "Don't Show",
       "codeInbox": "Code Inbox",
       "notesInbox": "Notes Inbox",
-      "tasksDue": "Tasks Due Today"
+      "tasksDue": "Tasks Due Today",
+      "permissionDenied": "macOS blocked the Dock counter. Allow notifications and badges for massCode in System Settings. Unsigned development builds may not support Dock badges."
     },
     "theme": {
       "label": "Theme",

--- a/src/main/i18n/locales/ru_RU/preferences.json
+++ b/src/main/i18n/locales/ru_RU/preferences.json
@@ -137,7 +137,8 @@
       "none": "Не показывать",
       "codeInbox": "Code Inbox",
       "notesInbox": "Notes Inbox",
-      "tasksDue": "Задачи на сегодня"
+      "tasksDue": "Задачи на сегодня",
+      "permissionDenied": "macOS заблокировала счётчик Dock. Разрешите уведомления и значки для massCode в системных настройках. Неподписанные dev-сборки могут не поддерживать значки Dock."
     },
     "theme": {
       "label": "Тема",

--- a/src/main/i18n/locales/ru_RU/preferences.json
+++ b/src/main/i18n/locales/ru_RU/preferences.json
@@ -132,6 +132,13 @@
   },
   "appearance": {
     "label": "Внешний вид",
+    "dockBadge": {
+      "label": "Счётчик на иконке в Dock",
+      "none": "Не показывать",
+      "codeInbox": "Code Inbox",
+      "notesInbox": "Notes Inbox",
+      "tasksDue": "Задачи на сегодня"
+    },
     "theme": {
       "label": "Тема",
       "builtIn": "Встроенные",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module'
 import path from 'node:path'
 import { app, BrowserWindow, ipcMain, Menu, protocol, screen } from 'electron'
 import { initApi } from './api'
+import { cleanupDockBadge, refreshDockBadge } from './dockBadge'
 import { registerIPC } from './ipc'
 import { startThemeWatcher, stopThemeWatcher } from './ipc/handlers/theme'
 import { validateStoredLicense } from './license'
@@ -271,6 +272,7 @@ else {
     setImmediate(() => {
       try {
         startMarkdownWatcher()
+        refreshDockBadge()
       }
       catch (error) {
         log('Error starting markdown watcher', error)
@@ -309,6 +311,7 @@ else {
     stopThemeWatcher()
     stopMarkdownWatcher()
     stopTasksCleanupScheduler()
+    cleanupDockBadge()
   })
 
   app.on('window-all-closed', () => {

--- a/src/main/ipc/handlers/__tests__/system.test.ts
+++ b/src/main/ipc/handlers/__tests__/system.test.ts
@@ -29,6 +29,8 @@ const i18nT = vi.fn()
 const log = vi.fn()
 const preferencesGet = vi.fn()
 const preferencesSet = vi.fn()
+const refreshDockBadge = vi.fn(() => 3)
+const scheduleDockBadgeRefresh = vi.fn()
 
 vi.mock('electron', () => ({
   app: {
@@ -61,6 +63,11 @@ vi.mock('../../../currencyRates', () => ({
   getCurrencyRates: vi.fn(),
   refreshCryptoRatesForced: vi.fn(),
   refreshFiatRatesForced: vi.fn(),
+}))
+
+vi.mock('../../../dockBadge', () => ({
+  refreshDockBadge,
+  scheduleDockBadgeRefresh,
 }))
 
 vi.mock('../../../i18n', () => ({
@@ -162,6 +169,21 @@ describe('registerSystemHandlers', () => {
       'system:set-vault-path',
       expect.any(Function),
     )
+  })
+
+  it('registers and delegates the Dock badge refresh handler', async () => {
+    const { registerSystemHandlers } = await import('../system')
+
+    registerSystemHandlers()
+
+    expect(handle).toHaveBeenCalledWith(
+      'system:refresh-dock-badge',
+      expect.any(Function),
+    )
+    expect(
+      registeredHandlers.get('system:refresh-dock-badge')?.(undefined),
+    ).toBe(3)
+    expect(refreshDockBadge).toHaveBeenCalledTimes(1)
   })
 
   it('delegates directory state lookup to the runtime helper', async () => {

--- a/src/main/ipc/handlers/__tests__/system.test.ts
+++ b/src/main/ipc/handlers/__tests__/system.test.ts
@@ -29,7 +29,7 @@ const i18nT = vi.fn()
 const log = vi.fn()
 const preferencesGet = vi.fn()
 const preferencesSet = vi.fn()
-const refreshDockBadge = vi.fn(() => 3)
+const refreshDockBadge = vi.fn(() => ({ applied: true, count: 3 }))
 const scheduleDockBadgeRefresh = vi.fn()
 
 vi.mock('electron', () => ({
@@ -182,7 +182,7 @@ describe('registerSystemHandlers', () => {
     )
     expect(
       registeredHandlers.get('system:refresh-dock-badge')?.(undefined),
-    ).toBe(3)
+    ).toEqual({ applied: true, count: 3 })
     expect(refreshDockBadge).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -9,6 +9,7 @@ import {
   refreshCryptoRatesForced,
   refreshFiatRatesForced,
 } from '../../currencyRates'
+import { refreshDockBadge, scheduleDockBadgeRefresh } from '../../dockBadge'
 import i18n from '../../i18n'
 import { activateLicense } from '../../license'
 import { getCloudDownloadStatus } from '../../storage/providers/markdown/cloudDownloads'
@@ -53,6 +54,7 @@ function setVaultPathAndRestartWatcher(vaultPath: string): void {
   try {
     store.preferences.set('storage.vaultPath', vaultPath)
     startMarkdownWatcher()
+    scheduleDockBadgeRefresh()
   }
   catch (error) {
     // Не оставляем приложение на частично запущенном watcher нового vault:
@@ -97,6 +99,7 @@ function moveVaultAndRestartWatcher(
 
   try {
     startMarkdownWatcher()
+    scheduleDockBadgeRefresh()
   }
   catch (error) {
     // Файлы уже перенесены, поэтому откат пути небезопасен. Чистый повтор
@@ -104,6 +107,7 @@ function moveVaultAndRestartWatcher(
     try {
       stopMarkdownWatcher()
       startMarkdownWatcher()
+      scheduleDockBadgeRefresh()
       return
     }
     catch (recoveryError) {
@@ -150,6 +154,10 @@ export function registerSystemHandlers() {
 
   ipcMain.handle('system:crypto-rates-refresh', () => {
     return refreshCryptoRatesForced()
+  })
+
+  ipcMain.handle('system:refresh-dock-badge', () => {
+    return refreshDockBadge()
   })
 
   ipcMain.handle(

--- a/src/main/storage/providers/markdown/notes/storages/folders.ts
+++ b/src/main/storage/providers/markdown/notes/storages/folders.ts
@@ -5,6 +5,7 @@ import type {
   NotesFoldersStorage,
 } from '../../../../contracts'
 import path from 'node:path'
+import { scheduleDockBadgeRefresh } from '../../../../../dockBadge'
 import { normalizeFlag, normalizeNumber } from '../../runtime/normalizers'
 import { getVaultPath } from '../../runtime/paths'
 import {
@@ -360,6 +361,7 @@ export function createNotesFoldersStorage(): NotesFoldersStorage {
 
       state.folders = state.folders.filter(f => !descendantIds.has(f.id))
       saveNotesState(paths, state)
+      scheduleDockBadgeRefresh()
 
       return { deleted: true }
     },

--- a/src/main/storage/providers/markdown/notes/storages/notes.ts
+++ b/src/main/storage/providers/markdown/notes/storages/notes.ts
@@ -13,6 +13,7 @@ import type {
 import type { MarkdownNote, NotesState } from '../runtime/types'
 import path from 'node:path'
 import { isAfter, isToday, parseISO, startOfToday } from 'date-fns'
+import { scheduleDockBadgeRefresh } from '../../../../../dockBadge'
 import { prioritizeCloudDownload } from '../../cloudDownloads'
 import { normalizeFlag } from '../../runtime/normalizers'
 import { getVaultPath } from '../../runtime/paths'
@@ -372,6 +373,7 @@ export function createNotesNotesStorage(): NotesStorage {
       })
 
       saveNotesState(paths, state)
+      scheduleDockBadgeRefresh()
 
       return result
     },
@@ -449,6 +451,7 @@ export function createNotesNotesStorage(): NotesStorage {
       }
 
       saveNotesState(paths, state)
+      scheduleDockBadgeRefresh()
       return { invalidInput: false, notFound: false }
     },
 
@@ -500,6 +503,7 @@ export function createNotesNotesStorage(): NotesStorage {
 
       note.updatedAt = Date.now()
       writeNoteToFile(paths, note)
+      scheduleDockBadgeRefresh()
 
       return { invalidInput: false, notFound: false }
     },
@@ -518,6 +522,7 @@ export function createNotesNotesStorage(): NotesStorage {
       }
 
       saveNotesState(paths, state)
+      scheduleDockBadgeRefresh()
       return result
     },
 
@@ -535,6 +540,7 @@ export function createNotesNotesStorage(): NotesStorage {
       }
 
       saveNotesState(paths, state)
+      scheduleDockBadgeRefresh()
       return result
     },
 

--- a/src/main/storage/providers/markdown/runtime/shared/vaultReconcile.ts
+++ b/src/main/storage/providers/markdown/runtime/shared/vaultReconcile.ts
@@ -2,6 +2,7 @@ import fsp from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { BrowserWindow } from 'electron'
+import { scheduleDockBadgeRefresh } from '../../../../../dockBadge'
 import { log } from '../../../../../utils'
 
 // Первый обход только что открытого vault опасен синхронно: листинг
@@ -17,6 +18,8 @@ import { log } from '../../../../../utils'
 const SKIP_WALK_DIR_NAMES = new Set(['.git', 'node_modules'])
 
 export function broadcastStorageSynced(): void {
+  scheduleDockBadgeRefresh()
+
   try {
     BrowserWindow.getAllWindows().forEach((window) => {
       window.webContents.send('system:storage-synced')

--- a/src/main/storage/providers/markdown/storages/folders.ts
+++ b/src/main/storage/providers/markdown/storages/folders.ts
@@ -1,6 +1,7 @@
 import type { FoldersStorage, FolderUpdateResult } from '../../../contracts'
 import path from 'node:path'
 import fs from 'fs-extra'
+import { scheduleDockBadgeRefresh } from '../../../../dockBadge'
 import {
   assertDirectoryNameAvailable,
   assertNotReservedRootFolderName,
@@ -331,6 +332,7 @@ export function createFoldersStorage(): FoldersStorage {
       removeFolderPathsFromDisk(paths.vaultPath, removedFolderPaths)
 
       saveState(paths, state)
+      scheduleDockBadgeRefresh()
 
       return { deleted: true }
     },

--- a/src/main/storage/providers/markdown/storages/snippets.ts
+++ b/src/main/storage/providers/markdown/storages/snippets.ts
@@ -9,6 +9,7 @@ import type {
   SnippetUpdateResult,
 } from '../../../contracts'
 import path from 'node:path'
+import { scheduleDockBadgeRefresh } from '../../../../dockBadge'
 import { prioritizeCloudDownload } from '../cloudDownloads'
 import {
   assertUniqueSiblingEntryName,
@@ -175,6 +176,7 @@ export function createSnippetsStorage(): SnippetsStorage {
       })
 
       saveState(paths, state)
+      scheduleDockBadgeRefresh()
 
       return result
     },
@@ -286,6 +288,7 @@ export function createSnippetsStorage(): SnippetsStorage {
         skipWriteIfUnavailable: movedToTrash,
       })
       saveState(paths, state)
+      scheduleDockBadgeRefresh()
 
       return {
         invalidInput: false,
@@ -441,6 +444,7 @@ export function createSnippetsStorage(): SnippetsStorage {
       }
 
       saveState(paths, state)
+      scheduleDockBadgeRefresh()
 
       return result
     },
@@ -458,6 +462,7 @@ export function createSnippetsStorage(): SnippetsStorage {
       }
 
       saveState(paths, state)
+      scheduleDockBadgeRefresh()
 
       return result
     },

--- a/src/main/store/__tests__/preferences.test.ts
+++ b/src/main/store/__tests__/preferences.test.ts
@@ -111,6 +111,41 @@ afterEach(() => {
 })
 
 describe('preferences store sanitization', () => {
+  it('defaults missing dock badge source to none', async () => {
+    const { default: preferences } = await import('../module/preferences')
+
+    expect(preferences.get('appearance.dockBadgeSource' as any)).toBe('none')
+  })
+
+  it('keeps a valid dock badge source and prunes stale appearance values', async () => {
+    persistedStateByName.preferences = {
+      appearance: {
+        theme: 'dark',
+        dockBadgeSource: 'notesInbox',
+        stale: true,
+      },
+    }
+
+    const { default: preferences } = await import('../module/preferences')
+
+    expect(preferences.get('appearance.dockBadgeSource' as any)).toBe(
+      'notesInbox',
+    )
+    expect(preferences.get('appearance.stale' as any)).toBeUndefined()
+  })
+
+  it('defaults an invalid dock badge source to none', async () => {
+    persistedStateByName.preferences = {
+      appearance: {
+        dockBadgeSource: 'invalid',
+      },
+    }
+
+    const { default: preferences } = await import('../module/preferences')
+
+    expect(preferences.get('appearance.dockBadgeSource' as any)).toBe('none')
+  })
+
   it('migrates legacy keys into grouped preferences schema and prunes stale values', async () => {
     persistedStateByName.preferences = {
       storagePath: '/custom-storage',

--- a/src/main/store/module/preferences.ts
+++ b/src/main/store/module/preferences.ts
@@ -49,6 +49,7 @@ const API_INTEGRATIONS_DEFAULTS: PreferencesStore['api']['integrations'] = {
 const PREFERENCES_DEFAULTS: PreferencesStore = {
   appearance: {
     theme: 'auto',
+    dockBadgeSource: 'none',
   },
   updates: {
     autoUpdate: true,
@@ -286,6 +287,12 @@ function sanitizePreferences(value: unknown): PreferencesStore {
         appearanceSource,
         'theme',
         readString(source, 'theme', PREFERENCES_DEFAULTS.appearance.theme),
+      ),
+      dockBadgeSource: readEnum(
+        appearanceSource,
+        'dockBadgeSource',
+        ['none', 'codeInbox', 'notesInbox', 'tasksDue'] as const,
+        PREFERENCES_DEFAULTS.appearance.dockBadgeSource,
       ),
     },
     updates: {

--- a/src/main/store/types/index.ts
+++ b/src/main/store/types/index.ts
@@ -237,6 +237,7 @@ export interface UpdatesSettings {
 }
 
 export type TasksAutoCleanupInterval = 'never' | '1d' | '7d' | '30d'
+export type DockBadgeSource = 'none' | 'codeInbox' | 'notesInbox' | 'tasksDue'
 
 export interface TasksSettings {
   autoCleanupCompleted: TasksAutoCleanupInterval
@@ -245,6 +246,7 @@ export interface TasksSettings {
 export interface PreferencesStore {
   appearance: {
     theme: string
+    dockBadgeSource: DockBadgeSource
   }
   updates: UpdatesSettings
   localization: {

--- a/src/main/types/ipc.ts
+++ b/src/main/types/ipc.ts
@@ -52,6 +52,7 @@ type SystemAction =
   | 'move-vault'
   | 'set-vault-path'
   | 'open-external'
+  | 'refresh-dock-badge'
   | 'show-http-request-in-file-manager'
   | 'show-notes-folder-in-file-manager'
   | 'show-note-in-file-manager'

--- a/src/renderer/components/preferences/Appearance.vue
+++ b/src/renderer/components/preferences/Appearance.vue
@@ -1,10 +1,40 @@
 <script setup lang="ts">
+import type { AcceptableValue } from 'reka-ui'
+import type { DockBadgeSource } from '~/main/store/types'
 import { Button } from '@/components/ui/shadcn/button'
 import * as Select from '@/components/ui/shadcn/select'
 import { useTheme } from '@/composables'
-import { i18n, ipc } from '@/electron'
+import { i18n, ipc, store } from '@/electron'
+import { isMac } from '@/utils'
 
 const { currentThemeId, customThemes, loadCustomThemes, setTheme } = useTheme()
+
+const dockBadgeSource = ref<DockBadgeSource>(
+  store.preferences.get<DockBadgeSource>('appearance.dockBadgeSource')
+  || 'none',
+)
+
+const dockBadgeOptions: Array<{ id: DockBadgeSource, label: string }> = [
+  {
+    id: 'none',
+    label: i18n.t('preferences:appearance.dockBadge.none'),
+  },
+  {
+    id: 'codeInbox',
+    label: i18n.t('preferences:appearance.dockBadge.codeInbox'),
+  },
+  {
+    id: 'notesInbox',
+    label: i18n.t('preferences:appearance.dockBadge.notesInbox'),
+  },
+  {
+    id: 'tasksDue',
+    label: i18n.t('preferences:appearance.dockBadge.tasksDue'),
+  },
+]
+const dockBadgeSources = new Set<DockBadgeSource>(
+  dockBadgeOptions.map(option => option.id),
+)
 
 const builtInThemes = [
   {
@@ -29,8 +59,24 @@ const customLightThemes = computed(() => {
   return customThemes.value.filter(theme => theme.type === 'light')
 })
 
-async function onThemeChange(id: string) {
-  await setTheme(id)
+async function onThemeChange(value: AcceptableValue) {
+  if (typeof value === 'string') {
+    await setTheme(value)
+  }
+}
+
+async function onDockBadgeSourceChange(value: AcceptableValue) {
+  if (
+    typeof value !== 'string'
+    || !dockBadgeSources.has(value as DockBadgeSource)
+  ) {
+    return
+  }
+
+  const source = value as DockBadgeSource
+  dockBadgeSource.value = source
+  store.preferences.set('appearance.dockBadgeSource', source)
+  await ipc.invoke('system:refresh-dock-badge', null)
 }
 
 async function openThemesDir() {
@@ -103,6 +149,29 @@ void loadCustomThemes()
                 </Select.SelectItem>
               </Select.SelectGroup>
             </template>
+          </Select.SelectContent>
+        </Select.Select>
+      </UiMenuFormItem>
+
+      <UiMenuFormItem
+        v-if="isMac"
+        :label="i18n.t('preferences:appearance.dockBadge.label')"
+      >
+        <Select.Select
+          :model-value="dockBadgeSource"
+          @update:model-value="onDockBadgeSourceChange"
+        >
+          <Select.SelectTrigger class="w-64">
+            <Select.SelectValue />
+          </Select.SelectTrigger>
+          <Select.SelectContent>
+            <Select.SelectItem
+              v-for="option in dockBadgeOptions"
+              :key="option.id"
+              :value="option.id"
+            >
+              {{ option.label }}
+            </Select.SelectItem>
           </Select.SelectContent>
         </Select.Select>
       </UiMenuFormItem>

--- a/src/renderer/components/preferences/Appearance.vue
+++ b/src/renderer/components/preferences/Appearance.vue
@@ -3,11 +3,17 @@ import type { AcceptableValue } from 'reka-ui'
 import type { DockBadgeSource } from '~/main/store/types'
 import { Button } from '@/components/ui/shadcn/button'
 import * as Select from '@/components/ui/shadcn/select'
-import { useTheme } from '@/composables'
+import { useSonner, useTheme } from '@/composables'
 import { i18n, ipc, store } from '@/electron'
 import { isMac } from '@/utils'
 
 const { currentThemeId, customThemes, loadCustomThemes, setTheme } = useTheme()
+const { sonner } = useSonner()
+
+interface DockBadgeRefreshResult {
+  applied: boolean
+  count: number
+}
 
 const dockBadgeSource = ref<DockBadgeSource>(
   store.preferences.get<DockBadgeSource>('appearance.dockBadgeSource')
@@ -76,7 +82,17 @@ async function onDockBadgeSourceChange(value: AcceptableValue) {
   const source = value as DockBadgeSource
   dockBadgeSource.value = source
   store.preferences.set('appearance.dockBadgeSource', source)
-  await ipc.invoke('system:refresh-dock-badge', null)
+  const result = (await ipc.invoke(
+    'system:refresh-dock-badge',
+    null,
+  )) as DockBadgeRefreshResult
+
+  if (source !== 'none' && !result.applied) {
+    sonner({
+      message: i18n.t('preferences:appearance.dockBadge.permissionDenied'),
+      type: 'warning',
+    })
+  }
 }
 
 async function openThemesDir() {


### PR DESCRIPTION
## Summary

- Add a macOS-only preference for Code Inbox, Notes Inbox, tasks due today, or no Dock counter.
- Calculate counters from runtime caches with overdue-task support, strict local dates, debounce, and midnight rollover.
- Refresh after relevant mutations, storage sync, vault changes, and startup.
- Warn users when macOS rejects badge updates.
- Add English/Russian localization and focused unit/IPC coverage.

## Testing

- 116 scoped tests passed.
- Scoped ESLint passed.
- Main-process TypeScript check passed.
- `pnpm i18n:copy` completed; locale keys are in parity.
- `git diff --check` passed.
- Renderer typecheck has no related errors; the full check remains blocked by pre-existing dependency errors.
