### PR TITLE
fix(notes): stabilize fenced code editing in live preview

### DIFF
--- a/src/renderer/components/notes/NotesEditor.vue
+++ b/src/renderer/components/notes/NotesEditor.vue
@@ -45,6 +45,7 @@ import {
 } from './cm-extensions/editorCommands'
 import { editorFocusExtension } from './cm-extensions/editorFocus'
 import { createExternalLinksNavigation } from './cm-extensions/externalLinks'
+import { fencedCodePairInput } from './cm-extensions/fencedCodeInput'
 import { createHideMarkup } from './cm-extensions/hideMarkup'
 import {
   createImageBlocks,
@@ -241,6 +242,10 @@ function createEditorState(doc: string): EditorState {
 
   if (notesSettings.lineNumbers && raw) {
     extensions.push(lineNumbersExtension())
+  }
+
+  if (editable && !raw) {
+    extensions.push(fencedCodePairInput)
   }
 
   if (!raw) {

--- a/src/renderer/components/notes/cm-extensions/__tests__/fencedCodeInput.test.ts
+++ b/src/renderer/components/notes/cm-extensions/__tests__/fencedCodeInput.test.ts
@@ -1,0 +1,152 @@
+import type { TransactionSpec } from '@codemirror/state'
+import type { EditorView } from '@codemirror/view'
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
+import { EditorSelection, EditorState } from '@codemirror/state'
+import { GFM } from '@lezer/markdown'
+import { describe, expect, it } from 'vitest'
+import {
+  computeFencedCodePairInput,
+  handleFencedCodePairInput,
+} from '../fencedCodeInput'
+
+function createState(
+  doc: string,
+  anchor: number,
+  head = anchor,
+  allowMultipleSelections = false,
+) {
+  return EditorState.create({
+    doc,
+    selection: EditorSelection.range(anchor, head),
+    extensions: [
+      EditorState.allowMultipleSelections.of(allowMultipleSelections),
+      markdown({ base: markdownLanguage, extensions: GFM }),
+    ],
+  })
+}
+
+function applyInput(doc: string, position: number) {
+  const state = createState(doc, position)
+  const result = computeFencedCodePairInput(state, position, position, '`')
+
+  expect(result).not.toBeNull()
+  const transaction = state.update({
+    changes: { from: position, insert: result!.insert },
+    selection: { anchor: result!.cursor },
+  })
+
+  return {
+    doc: transaction.state.doc.toString(),
+    cursor: transaction.state.selection.main.head,
+  }
+}
+
+describe('computeFencedCodePairInput', () => {
+  it('creates an empty pair before existing line content', () => {
+    expect(applyInput('``adasd', 2)).toEqual({
+      doc: ['```', '```', 'adasd'].join('\n'),
+      cursor: 3,
+    })
+  })
+
+  it.each([
+    ['end of document', '``'],
+    ['empty line before another line', ['``', 'next'].join('\n')],
+  ])('creates an empty pair at %s', (_, doc) => {
+    expect(applyInput(doc, 2)).toEqual({
+      doc: ['```', '```', ...doc.slice(2).split('\n').slice(1)].join('\n'),
+      cursor: 3,
+    })
+  })
+
+  it('leaves the cursor after the opening fence for CodeInfo', () => {
+    const paired = applyInput('``', 2)
+    const state = createState(paired.doc, paired.cursor)
+    const withLanguage = state.update({
+      changes: { from: paired.cursor, insert: 'bash' },
+      selection: { anchor: paired.cursor + 4 },
+    }).state
+
+    expect(withLanguage.doc.toString()).toBe(['```bash', '```'].join('\n'))
+    expect(withLanguage.selection.main.head).toBe(7)
+  })
+
+  it('does not intercept a closing fence inside FencedCode', () => {
+    const doc = ['```', 'code', '``'].join('\n')
+    const state = createState(doc, doc.length)
+
+    expect(
+      computeFencedCodePairInput(state, doc.length, doc.length, '`'),
+    ).toBeNull()
+  })
+
+  it('ignores inline text, non-empty selections, and multi-character input', () => {
+    const inline = createState('text ``', 7)
+    const selection = createState('``adasd', 0, 2)
+    const emptyLine = createState('``', 2)
+
+    expect(computeFencedCodePairInput(inline, 7, 7, '`')).toBeNull()
+    expect(computeFencedCodePairInput(selection, 0, 2, '`')).toBeNull()
+    expect(computeFencedCodePairInput(emptyLine, 2, 2, '``')).toBeNull()
+  })
+
+  it('keeps an existing fenced block below the new empty pair', () => {
+    const existing = ['```js', 'const value = 1', '```'].join('\n')
+
+    expect(applyInput(['``', existing].join('\n'), 2)).toEqual({
+      doc: ['```', '```', existing].join('\n'),
+      cursor: 3,
+    })
+  })
+
+  it('ignores multiple selections', () => {
+    const state = createState('``\n``', 2, 2, true).update({
+      selection: EditorSelection.create([
+        EditorSelection.cursor(2),
+        EditorSelection.cursor(5),
+      ]),
+    }).state
+
+    expect(computeFencedCodePairInput(state, 2, 2, '`')).toBeNull()
+  })
+})
+
+describe('handleFencedCodePairInput', () => {
+  function run(userEvent: string, composing = false) {
+    let state = createState('``', 2)
+    let dispatchCount = 0
+    const view = {
+      get state() {
+        return state
+      },
+      composing,
+      dispatch(spec: TransactionSpec) {
+        dispatchCount++
+        state = state.update(spec).state
+      },
+    } as EditorView
+    const insert = () =>
+      state.update({
+        changes: { from: 2, insert: '`' },
+        userEvent,
+      })
+
+    const handled = handleFencedCodePairInput(view, 2, 2, '`', insert)
+
+    return { handled, dispatchCount, doc: state.doc.toString() }
+  }
+
+  it('handles manual typing in one atomic dispatch', () => {
+    expect(run('input.type')).toEqual({
+      handled: true,
+      dispatchCount: 1,
+      doc: ['```', '```'].join('\n'),
+    })
+  })
+
+  it('does not handle paste or IME composition', () => {
+    expect(run('input.paste').handled).toBe(false)
+    expect(run('input.type.compose', true).handled).toBe(false)
+    expect(run('input.type.compose').handled).toBe(false)
+  })
+})

--- a/src/renderer/components/notes/cm-extensions/__tests__/fencedCodeStyles.test.ts
+++ b/src/renderer/components/notes/cm-extensions/__tests__/fencedCodeStyles.test.ts
@@ -1,3 +1,4 @@
+import type { SyntaxNode } from '@lezer/common'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { syntaxTree } from '@codemirror/language'
 import { languages } from '@codemirror/language-data'
@@ -20,46 +21,57 @@ function getFencedCodeNodes(doc: string) {
       }),
     ],
   })
-  const nodes: Array<{ name: string, from: number, to: number }> = []
+  const nodes: SyntaxNode[] = []
 
   syntaxTree(state).iterate({
     enter(node) {
       if (node.name === 'FencedCode')
-        nodes.push({ name: node.name, from: node.from, to: node.to })
+        nodes.push(node.node)
     },
   })
 
-  return { state, nodes }
+  return nodes
 }
 
 describe('isStandaloneFencedCode', () => {
-  it('detects the trailing standalone fence from a damaged opening marker', () => {
-    const { state, nodes } = getFencedCodeNodes(
+  it.each(['```', '```\n', '```bash', '```bash\n'])(
+    'detects a standalone fence in %j',
+    (doc) => {
+      const nodes = getFencedCodeNodes(doc)
+
+      expect(nodes).toHaveLength(1)
+      expect(isStandaloneFencedCode(nodes[0])).toBe(true)
+    },
+  )
+
+  it.each([
+    ['multiline unclosed fence', ['```', 'code'].join('\n')],
+    ['multiline unclosed fence with info', ['```bash', 'code'].join('\n')],
+    ['empty multiline unclosed fence', ['```', '', ''].join('\n')],
+    ['valid empty fenced block', ['```', '```'].join('\n')],
+  ])('keeps a %s', (_, doc) => {
+    const nodes = getFencedCodeNodes(doc)
+
+    expect(nodes).toHaveLength(1)
+    expect(isStandaloneFencedCode(nodes[0])).toBe(false)
+  })
+
+  it('distinguishes a valid block from a trailing fence with a final LF', () => {
+    const nodes = getFencedCodeNodes(
       [
-        '``',
+        '```',
+        'adasd',
+        'adasdasdas',
+        '',
+        '```',
         'grep -h \'"event":"observability_evidence"\' /root/.pm2/logs/Api-out*.log | tail -n 1',
         '```',
+        '',
       ].join('\n'),
     )
 
-    expect(nodes).toHaveLength(1)
-    expect(isStandaloneFencedCode(state, nodes[0])).toBe(true)
-  })
-
-  it('keeps a valid fenced block', () => {
-    const { state, nodes } = getFencedCodeNodes(
-      ['```', 'command', '```'].join('\n'),
-    )
-
-    expect(nodes).toHaveLength(1)
-    expect(isStandaloneFencedCode(state, nodes[0])).toBe(false)
-  })
-
-  it('keeps a multiline unclosed fenced block', () => {
-    const { state, nodes } = getFencedCodeNodes(['```', 'command'].join('\n'))
-
-    expect(nodes).toHaveLength(1)
-    expect(isStandaloneFencedCode(state, nodes[0])).toBe(false)
+    expect(nodes).toHaveLength(2)
+    expect(nodes.map(isStandaloneFencedCode)).toEqual([false, true])
   })
 })
 

--- a/src/renderer/components/notes/cm-extensions/__tests__/fencedCodeStyles.test.ts
+++ b/src/renderer/components/notes/cm-extensions/__tests__/fencedCodeStyles.test.ts
@@ -1,5 +1,67 @@
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
+import { syntaxTree } from '@codemirror/language'
+import { languages } from '@codemirror/language-data'
+import { EditorState } from '@codemirror/state'
+import { GFM } from '@lezer/markdown'
 import { describe, expect, it } from 'vitest'
-import { buildFencedCodeLineStyle } from '../fencedCodeStyles'
+import {
+  buildFencedCodeLineStyle,
+  isStandaloneFencedCode,
+} from '../fencedCodeStyles'
+
+function getFencedCodeNodes(doc: string) {
+  const state = EditorState.create({
+    doc,
+    extensions: [
+      markdown({
+        base: markdownLanguage,
+        codeLanguages: languages,
+        extensions: GFM,
+      }),
+    ],
+  })
+  const nodes: Array<{ name: string, from: number, to: number }> = []
+
+  syntaxTree(state).iterate({
+    enter(node) {
+      if (node.name === 'FencedCode')
+        nodes.push({ name: node.name, from: node.from, to: node.to })
+    },
+  })
+
+  return { state, nodes }
+}
+
+describe('isStandaloneFencedCode', () => {
+  it('detects the trailing standalone fence from a damaged opening marker', () => {
+    const { state, nodes } = getFencedCodeNodes(
+      [
+        '``',
+        'grep -h \'"event":"observability_evidence"\' /root/.pm2/logs/Api-out*.log | tail -n 1',
+        '```',
+      ].join('\n'),
+    )
+
+    expect(nodes).toHaveLength(1)
+    expect(isStandaloneFencedCode(state, nodes[0])).toBe(true)
+  })
+
+  it('keeps a valid fenced block', () => {
+    const { state, nodes } = getFencedCodeNodes(
+      ['```', 'command', '```'].join('\n'),
+    )
+
+    expect(nodes).toHaveLength(1)
+    expect(isStandaloneFencedCode(state, nodes[0])).toBe(false)
+  })
+
+  it('keeps a multiline unclosed fenced block', () => {
+    const { state, nodes } = getFencedCodeNodes(['```', 'command'].join('\n'))
+
+    expect(nodes).toHaveLength(1)
+    expect(isStandaloneFencedCode(state, nodes[0])).toBe(false)
+  })
+})
 
 describe('buildFencedCodeLineStyle', () => {
   it('does not use margins in line decorations', () => {

--- a/src/renderer/components/notes/cm-extensions/__tests__/hideMarkup.test.ts
+++ b/src/renderer/components/notes/cm-extensions/__tests__/hideMarkup.test.ts
@@ -1,5 +1,74 @@
+import type { SyntaxNode } from '@lezer/common'
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
+import { syntaxTree } from '@codemirror/language'
+import { languages } from '@codemirror/language-data'
+import { EditorState } from '@codemirror/state'
+import { GFM } from '@lezer/markdown'
 import { describe, expect, it } from 'vitest'
-import { canShowMarkup, shouldHideUrlNodeInMarkup } from '../hideMarkup'
+import {
+  canShowMarkup,
+  shouldHideUrlNodeInMarkup,
+  shouldKeepStandaloneFencedCodeMarkup,
+} from '../hideMarkup'
+
+function getFencedMarkupNodes(doc: string) {
+  const state = EditorState.create({
+    doc,
+    extensions: [
+      markdown({
+        base: markdownLanguage,
+        codeLanguages: languages,
+        extensions: GFM,
+      }),
+    ],
+  })
+  const nodes: Array<{ name: string, parent: SyntaxNode }> = []
+
+  syntaxTree(state).iterate({
+    enter(node) {
+      const parent = node.node.parent
+      if (
+        (node.name === 'CodeMark' || node.name === 'CodeInfo')
+        && parent?.name === 'FencedCode'
+      ) {
+        nodes.push({ name: node.name, parent })
+      }
+    },
+  })
+
+  return nodes
+}
+
+describe('standalone fenced code markup visibility', () => {
+  it('keeps CodeMark and CodeInfo for a standalone fence', () => {
+    const nodes = getFencedMarkupNodes('```bash\n')
+
+    expect(
+      nodes.map(node => [
+        node.name,
+        shouldKeepStandaloneFencedCodeMarkup(node.name, node.parent),
+      ]),
+    ).toEqual([
+      ['CodeMark', true],
+      ['CodeInfo', true],
+    ])
+  })
+
+  it('does not keep CodeMark or CodeInfo for a regular fenced block', () => {
+    const nodes = getFencedMarkupNodes(['```bash', 'code', '```'].join('\n'))
+
+    expect(nodes.map(node => node.name)).toEqual([
+      'CodeMark',
+      'CodeInfo',
+      'CodeMark',
+    ])
+    expect(
+      nodes.map(node =>
+        shouldKeepStandaloneFencedCodeMarkup(node.name, node.parent),
+      ),
+    ).toEqual([false, false, false])
+  })
+})
 
 describe('hideMarkup url visibility', () => {
   it('hides URL node inside markdown link', () => {

--- a/src/renderer/components/notes/cm-extensions/fencedCodeInput.ts
+++ b/src/renderer/components/notes/cm-extensions/fencedCodeInput.ts
@@ -1,0 +1,98 @@
+import type { EditorState, Transaction } from '@codemirror/state'
+import type { EditorView as EditorViewType } from '@codemirror/view'
+import { syntaxTree } from '@codemirror/language'
+import { EditorView } from '@codemirror/view'
+
+type SyntaxNode = ReturnType<ReturnType<typeof syntaxTree>['resolveInner']>
+
+const FENCE = '```'
+
+interface FencedCodePairInput {
+  insert: string
+  cursor: number
+}
+
+function isInsideFencedCode(state: EditorState, position: number): boolean {
+  const tree = syntaxTree(state)
+
+  for (const side of [-1, 1] as const) {
+    let node: SyntaxNode | null = tree.resolveInner(position, side)
+
+    while (node) {
+      if (node.name === 'FencedCode')
+        return true
+
+      node = node.parent
+    }
+  }
+
+  return false
+}
+
+export function computeFencedCodePairInput(
+  state: EditorState,
+  from: number,
+  to: number,
+  text: string,
+): FencedCodePairInput | null {
+  const ranges = state.selection.ranges
+  if (
+    text !== '`'
+    || ranges.length !== 1
+    || !ranges[0].empty
+    || ranges[0].from !== from
+    || ranges[0].to !== to
+  ) {
+    return null
+  }
+
+  const line = state.doc.lineAt(from)
+  if (state.sliceDoc(line.from, from) !== '``')
+    return null
+
+  if (isInsideFencedCode(state, from))
+    return null
+
+  const suffix = state.sliceDoc(from, line.to)
+
+  return {
+    insert: `\`\n${FENCE}${suffix ? '\n' : ''}`,
+    cursor: from + 1,
+  }
+}
+
+export function handleFencedCodePairInput(
+  view: EditorViewType,
+  from: number,
+  to: number,
+  text: string,
+  insert: () => Transaction,
+): boolean {
+  if (view.composing)
+    return false
+
+  const defaultTransaction = insert()
+  if (
+    !defaultTransaction.isUserEvent('input.type')
+    || defaultTransaction.isUserEvent('input.type.compose')
+  ) {
+    return false
+  }
+
+  const result = computeFencedCodePairInput(view.state, from, to, text)
+  if (!result)
+    return false
+
+  view.dispatch({
+    changes: { from, to, insert: result.insert },
+    selection: { anchor: result.cursor },
+    scrollIntoView: true,
+    userEvent: 'input.type',
+  })
+
+  return true
+}
+
+export const fencedCodePairInput = EditorView.inputHandler.of(
+  handleFencedCodePairInput,
+)

--- a/src/renderer/components/notes/cm-extensions/fencedCodeStyles.ts
+++ b/src/renderer/components/notes/cm-extensions/fencedCodeStyles.ts
@@ -1,3 +1,5 @@
+import type { EditorState } from '@codemirror/state'
+
 const fencedCodeBaseStyle = [
   'background:var(--card)',
   'border-left:1px solid var(--border)',
@@ -10,6 +12,16 @@ const fencedCodeBaseStyle = [
   'padding-left:16px',
   'padding-right:16px',
 ].join(';')
+
+export function isStandaloneFencedCode(
+  state: EditorState,
+  node: { name: string, from: number, to: number },
+): boolean {
+  return (
+    node.name === 'FencedCode'
+    && state.doc.lineAt(node.from).number === state.doc.lineAt(node.to).number
+  )
+}
 
 export function buildFencedCodeLineStyle(
   lineNumber: number,

--- a/src/renderer/components/notes/cm-extensions/fencedCodeStyles.ts
+++ b/src/renderer/components/notes/cm-extensions/fencedCodeStyles.ts
@@ -1,4 +1,4 @@
-import type { EditorState } from '@codemirror/state'
+import type { SyntaxNode } from '@lezer/common'
 
 const fencedCodeBaseStyle = [
   'background:var(--card)',
@@ -13,13 +13,11 @@ const fencedCodeBaseStyle = [
   'padding-right:16px',
 ].join(';')
 
-export function isStandaloneFencedCode(
-  state: EditorState,
-  node: { name: string, from: number, to: number },
-): boolean {
+export function isStandaloneFencedCode(node: SyntaxNode): boolean {
   return (
     node.name === 'FencedCode'
-    && state.doc.lineAt(node.from).number === state.doc.lineAt(node.to).number
+    && node.getChildren('CodeMark').length === 1
+    && node.getChild('CodeText') === null
   )
 }
 

--- a/src/renderer/components/notes/cm-extensions/hideMarkup.ts
+++ b/src/renderer/components/notes/cm-extensions/hideMarkup.ts
@@ -2,6 +2,7 @@ import type { EditorState, Range } from '@codemirror/state'
 import type { EditorView } from '@codemirror/view'
 import { syntaxTree } from '@codemirror/language'
 import { Decoration, ViewPlugin } from '@codemirror/view'
+import { isStandaloneFencedCode } from './fencedCodeStyles'
 import { getRevealSelection, revealSelectionChanged } from './revealSelection'
 
 const HIDEABLE_MARKS = new Set([
@@ -126,6 +127,15 @@ function buildHideDecorations(view: EditorView, alwaysHide: boolean) {
 
         if (isInternalLinkBracket(view, node))
           return
+
+        const parent = node.node.parent
+        if (
+          node.name === 'CodeMark'
+          && parent
+          && isStandaloneFencedCode(view.state, parent)
+        ) {
+          return
+        }
 
         if (shouldShowMark(view, node, alwaysHide))
           return

--- a/src/renderer/components/notes/cm-extensions/hideMarkup.ts
+++ b/src/renderer/components/notes/cm-extensions/hideMarkup.ts
@@ -1,5 +1,6 @@
 import type { EditorState, Range } from '@codemirror/state'
 import type { EditorView } from '@codemirror/view'
+import type { SyntaxNode } from '@lezer/common'
 import { syntaxTree } from '@codemirror/language'
 import { Decoration, ViewPlugin } from '@codemirror/view'
 import { isStandaloneFencedCode } from './fencedCodeStyles'
@@ -35,6 +36,17 @@ export function shouldHideUrlNodeInMarkup(
   }
 
   return parentName === 'Link' || parentName === 'Image'
+}
+
+export function shouldKeepStandaloneFencedCodeMarkup(
+  nodeName: string,
+  parent: SyntaxNode | null,
+): boolean {
+  return (
+    (nodeName === 'CodeMark' || nodeName === 'CodeInfo')
+    && parent !== null
+    && isStandaloneFencedCode(parent)
+  )
 }
 
 function isInternalLinkBracket(
@@ -128,12 +140,7 @@ function buildHideDecorations(view: EditorView, alwaysHide: boolean) {
         if (isInternalLinkBracket(view, node))
           return
 
-        const parent = node.node.parent
-        if (
-          node.name === 'CodeMark'
-          && parent
-          && isStandaloneFencedCode(view.state, parent)
-        ) {
+        if (shouldKeepStandaloneFencedCodeMarkup(node.name, node.node.parent)) {
           return
         }
 

--- a/src/renderer/components/notes/cm-extensions/markdownDecorations.ts
+++ b/src/renderer/components/notes/cm-extensions/markdownDecorations.ts
@@ -10,7 +10,10 @@ import {
   parseBlockquoteCallout,
   shouldReplaceCalloutMarker,
 } from './callouts'
-import { buildFencedCodeLineStyle } from './fencedCodeStyles'
+import {
+  buildFencedCodeLineStyle,
+  isStandaloneFencedCode,
+} from './fencedCodeStyles'
 import { getRevealSelection, revealSelectionChanged } from './revealSelection'
 
 class HorizontalRuleWidget extends WidgetType {
@@ -478,6 +481,9 @@ function buildDecorations(
 
         // Fenced code blocks
         if (type === 'FencedCode') {
+          if (isStandaloneFencedCode(view.state, node))
+            return
+
           const startLine = view.state.doc.lineAt(node.from)
           const endLine = view.state.doc.lineAt(node.to)
 

--- a/src/renderer/components/notes/cm-extensions/markdownDecorations.ts
+++ b/src/renderer/components/notes/cm-extensions/markdownDecorations.ts
@@ -481,7 +481,7 @@ function buildDecorations(
 
         // Fenced code blocks
         if (type === 'FencedCode') {
-          if (isStandaloneFencedCode(view.state, node))
+          if (isStandaloneFencedCode(node.node))
             return
 
           const startLine = view.state.doc.lineAt(node.from)


### PR DESCRIPTION
## Summary

- render standalone fenced-code markers as Markdown instead of empty code blocks
- automatically insert a matching closing fence when typing an opening fence in editable live preview
- preserve regular, unclosed, pasted, composed, and multi-selection input behavior

## Verification

- 41 scoped tests
- scoped ESLint
- targeted strict TypeScript check
- git diff --check