### PR TITLE
feat: add line break normalization

### DIFF
--- a/src/main/i18n/locales/en_US/devtools.json
+++ b/src/main/i18n/locales/en_US/devtools.json
@@ -115,6 +115,10 @@
         "asciiToText": "ASCII → Text"
       }
     },
+    "lineBreakNormalizer": {
+      "label": "Line Break Normalizer",
+      "description": "Remove hard line wraps and normalize pasted terminal text"
+    },
     "base64": {
       "label": "Base64 Encoder / Decoder",
       "description": "Encode or decode text to Base64",

--- a/src/main/i18n/locales/en_US/menu.json
+++ b/src/main/i18n/locales/en_US/menu.json
@@ -69,6 +69,7 @@
     "copySnippet": "Copy Snippet",
     "copyNote": "Copy Note",
     "format": "Format",
+    "normalizeTerminalOutput": "Normalize Line Breaks",
     "mode": "Mode",
     "modeRaw": "Raw",
     "modeLivePreview": "Live Preview",

--- a/src/main/i18n/locales/ru_RU/devtools.json
+++ b/src/main/i18n/locales/ru_RU/devtools.json
@@ -115,6 +115,10 @@
         "asciiToText": "ASCII → Текст"
       }
     },
+    "lineBreakNormalizer": {
+      "label": "Нормализатор переносов строк",
+      "description": "Удаление жёстких переносов строк и нормализация текста из терминала"
+    },
     "base64": {
       "label": "Base64 Encoder / Decoder",
       "description": "Кодирование или декодирование текста в Base64",

--- a/src/main/i18n/locales/ru_RU/menu.json
+++ b/src/main/i18n/locales/ru_RU/menu.json
@@ -69,6 +69,7 @@
     "copySnippet": "Копировать сниппет",
     "copyNote": "Копировать заметку",
     "format": "Форматировать",
+    "normalizeTerminalOutput": "Нормализовать переносы строк",
     "mode": "Режим",
     "modeRaw": "Исходный",
     "modeLivePreview": "Живой предпросмотр",

--- a/src/main/menu/__tests__/main.test.ts
+++ b/src/main/menu/__tests__/main.test.ts
@@ -2,6 +2,7 @@ import type { MainMenuContext } from '../../types/menu'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const buildFromTemplate = vi.fn((template: unknown) => template)
+const send = vi.fn()
 
 vi.mock('electron', () => ({
   app: {
@@ -30,7 +31,7 @@ vi.mock('../../i18n', () => ({
 }))
 
 vi.mock('../../ipc', () => ({
-  send: vi.fn(),
+  send,
 }))
 
 vi.mock('../../updates', () => ({
@@ -41,9 +42,53 @@ vi.mock('../../../../package.json', () => ({
   repository: 'https://example.com/repo',
 }))
 
+function createNotesContext(
+  options: {
+    canToggleMindmap?: boolean
+    isMindmapShown?: boolean
+    isPresentationShown?: boolean
+    noteMode?: MainMenuContext['editor']['noteMode']
+  } = {},
+): MainMenuContext {
+  return {
+    file: {
+      primaryAction: 'new-note',
+      secondaryAction: 'new-folder',
+      canCreateFragment: false,
+      canCreateTask: true,
+    },
+    view: {
+      layoutMode: 'all-panels',
+      layoutModes: ['all-panels', 'list-editor', 'editor-only'],
+      contentSortField: 'updatedAt',
+      contentSortOrder: 'DESC',
+      canToggleCompactMode: true,
+      canToggleHideCompletedTasks: false,
+      isHideCompletedTasksInFolders: false,
+      canToggleMindmap: options.canToggleMindmap ?? true,
+      isCompactMode: false,
+      isMindmapShown: options.isMindmapShown ?? false,
+      canTogglePresentation: true,
+      isPresentationShown: options.isPresentationShown ?? false,
+    },
+    editor: {
+      kind: 'notes',
+      noteMode: options.noteMode ?? 'livePreview',
+      canSendRequest: false,
+      canFormat: false,
+      canPreviewCode: false,
+      isCodePreviewShown: false,
+      canPreviewJson: false,
+      isJsonPreviewShown: false,
+      canAdjustFontSize: true,
+    },
+  }
+}
+
 describe('createMainMenu', () => {
   beforeEach(() => {
     buildFromTemplate.mockClear()
+    send.mockClear()
   })
 
   it('renders file and view actions on the first submenu level', async () => {
@@ -87,11 +132,18 @@ describe('createMainMenu', () => {
 
     const template = buildFromTemplate.mock.calls[0]?.[0] as Array<{
       label?: string
-      submenu?: Array<{ label?: string, submenu?: unknown[] }>
+      submenu?: Array<{
+        label?: string
+        submenu?: unknown[]
+        click?: () => void
+      }>
     }>
 
     const fileMenu = template.find(item => item.label === 'menu:file.label')
     const viewMenu = template.find(item => item.label === 'menu:view.label')
+    const editorMenu = template.find(
+      item => item.label === 'menu:editor.label',
+    )
 
     expect(fileMenu?.submenu?.map(item => item.label)).toEqual([
       'action.new.snippet',
@@ -121,6 +173,75 @@ describe('createMainMenu', () => {
     expect(viewMenu?.submenu?.some(item => Array.isArray(item.submenu))).toBe(
       false,
     )
+
+    const editorLabels = editorMenu?.submenu?.map(item => item.label) ?? []
+    const formatIndex = editorLabels.indexOf('menu:editor.format')
+
+    expect(editorLabels[formatIndex + 1]).toBe(
+      'menu:editor.normalizeTerminalOutput',
+    )
+
+    editorMenu?.submenu
+      ?.find(item => item.label === 'menu:editor.normalizeTerminalOutput')
+      ?.click?.()
+
+    expect(send).toHaveBeenCalledWith('main-menu:normalize-code-line-breaks')
+    expect(
+      editorMenu?.submenu?.find(
+        item => item.label === 'menu:editor.normalizeTerminalOutput',
+      ),
+    ).toMatchObject({ enabled: true })
+  })
+
+  it('enables line break normalization for an editable selected note', async () => {
+    const { createMainMenu } = await import('../main')
+
+    createMainMenu(createNotesContext())
+
+    const template = buildFromTemplate.mock.calls[0]?.[0] as Array<{
+      label?: string
+      submenu?: Array<{
+        label?: string
+        enabled?: boolean
+        click?: () => void
+      }>
+    }>
+    const editorMenu = template.find(
+      item => item.label === 'menu:editor.label',
+    )
+
+    const normalizeItem = editorMenu?.submenu?.find(
+      item => item.label === 'menu:editor.normalizeTerminalOutput',
+    )
+
+    expect(normalizeItem).toMatchObject({ enabled: true })
+    normalizeItem?.click?.()
+    expect(send).toHaveBeenCalledWith('main-menu:normalize-note-line-breaks')
+  })
+
+  it.each([
+    ['preview mode', { noteMode: 'preview' as const }],
+    ['no selected note', { canToggleMindmap: false }],
+    ['mindmap mode', { isMindmapShown: true }],
+    ['presentation mode', { isPresentationShown: true }],
+  ])('disables line break normalization in %s', async (_label, options) => {
+    const { createMainMenu } = await import('../main')
+
+    createMainMenu(createNotesContext(options))
+
+    const template = buildFromTemplate.mock.calls[0]?.[0] as Array<{
+      label?: string
+      submenu?: Array<{ label?: string, enabled?: boolean }>
+    }>
+    const editorMenu = template.find(
+      item => item.label === 'menu:editor.label',
+    )
+
+    expect(
+      editorMenu?.submenu?.find(
+        item => item.label === 'menu:editor.normalizeTerminalOutput',
+      ),
+    ).toMatchObject({ enabled: false })
   })
 
   it('omits compact mode when the current space has no list', async () => {

--- a/src/main/menu/main.ts
+++ b/src/main/menu/main.ts
@@ -555,6 +555,11 @@ function createEditorMenuItems(context: MainMenuContext): MenuConfig[] {
       click: () => send('main-menu:format'),
     })
     items.push({
+      label: i18n.t('menu:editor.normalizeTerminalOutput'),
+      enabled: true,
+      click: () => send('main-menu:normalize-code-line-breaks'),
+    })
+    items.push({
       label: i18n.t('menu:editor.previewCode'),
       type: 'checkbox',
       enabled: context.editor.canPreviewCode,
@@ -577,6 +582,16 @@ function createEditorMenuItems(context: MainMenuContext): MenuConfig[] {
       label: i18n.t('menu:editor.copyNote'),
       click: () => send('main-menu:copy-note'),
       accelerator: 'CommandOrControl+Shift+C',
+    })
+    items.push({
+      label: i18n.t('menu:editor.normalizeTerminalOutput'),
+      enabled:
+        context.editor.noteMode !== null
+        && context.editor.noteMode !== 'preview'
+        && context.view.canToggleMindmap
+        && !context.view.isMindmapShown
+        && !context.view.isPresentationShown,
+      click: () => send('main-menu:normalize-note-line-breaks'),
     })
   }
 

--- a/src/main/types/ipc.ts
+++ b/src/main/types/ipc.ts
@@ -11,6 +11,8 @@ type MainMenuAction =
   | 'font-size-increase'
   | 'font-size-reset'
   | 'format'
+  | 'normalize-code-line-breaks'
+  | 'normalize-note-line-breaks'
   | 'goto-preferences'
   | 'goto-devtools'
   | 'new-note'

--- a/src/renderer/components/devtools/converters/LineBreakNormalizer.vue
+++ b/src/renderer/components/devtools/converters/LineBreakNormalizer.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { Button } from '@/components/ui/shadcn/button'
+import { useCopyToClipboard } from '@/composables'
+import { i18n } from '@/electron'
+import { normalizeTerminalText } from '@/utils/normalizeTerminalText'
+
+const input = ref('')
+const output = computed(() => normalizeTerminalText(input.value))
+
+const copy = useCopyToClipboard()
+
+const title = computed(() =>
+  i18n.t('devtools:converters.lineBreakNormalizer.label'),
+)
+const description = computed(() =>
+  i18n.t('devtools:converters.lineBreakNormalizer.description'),
+)
+</script>
+
+<template>
+  <div class="space-y-6">
+    <UiHeading
+      :title="title"
+      :description="description"
+    />
+    <div class="space-y-2">
+      <UiHeading
+        :title="i18n.t('devtools:form.input')"
+        :level="3"
+      />
+      <UiInput
+        v-model="input"
+        :placeholder="i18n.t('devtools:form.placeholder.text')"
+        clearable
+        type="textarea"
+      />
+    </div>
+    <div class="space-y-4">
+      <UiHeading
+        :title="i18n.t('devtools:form.output')"
+        :level="3"
+      />
+      <UiInput
+        :model-value="output"
+        type="textarea"
+        readonly
+      />
+      <Button
+        variant="outline"
+        @click="copy(output)"
+      >
+        {{ i18n.t("button.copy") }}
+      </Button>
+    </div>
+  </div>
+</template>

--- a/src/renderer/components/editor/Editor.vue
+++ b/src/renderer/components/editor/Editor.vue
@@ -10,6 +10,10 @@ import {
   useTheme,
 } from '@/composables'
 import { i18n, ipc } from '@/electron'
+import {
+  mapNormalizedCursorIndex,
+  normalizeTerminalText,
+} from '@/utils/normalizeTerminalText'
 import { useClipboard, useCssVar, useDebounceFn } from '@vueuse/core'
 import CodeMirror from 'codemirror'
 import 'codemirror/addon/edit/closebrackets'
@@ -428,7 +432,35 @@ function onCopySnippetMenu() {
   useDonations().incrementCopy('code')
 }
 
+function normalizeTerminalOutput() {
+  if (!editor)
+    return
+
+  if (editor.somethingSelected()) {
+    const selections = editor.getSelections()
+    const normalized = selections.map(normalizeTerminalText)
+
+    if (normalized.some((value, index) => value !== selections[index]))
+      editor.replaceSelections(normalized, 'around')
+
+    return
+  }
+
+  const value = editor.getValue()
+  const normalized = normalizeTerminalText(value)
+
+  if (normalized === value)
+    return
+
+  const cursorIndex = editor.indexFromPos(editor.getCursor())
+  const mappedIndex = mapNormalizedCursorIndex(value, cursorIndex, normalized)
+
+  setValue(normalized, false)
+  editor.setCursor(editor.posFromIndex(mappedIndex))
+}
+
 ipc.on('main-menu:format', format)
+ipc.on('main-menu:normalize-code-line-breaks', normalizeTerminalOutput)
 
 // Спейсы пересоздаются при переключении: без снятия listeners каждый цикл
 // добавляет обработчик и удерживает мёртвый инстанс CodeMirror от GC.
@@ -437,6 +469,7 @@ ipc.on('main-menu:format', format)
 // этот компонент.
 onBeforeUnmount(() => {
   ipc.removeListeners('main-menu:format')
+  ipc.removeListeners('main-menu:normalize-code-line-breaks')
   ipc.removeListeners('main-menu:copy-snippet')
 })
 

--- a/src/renderer/components/notes/NotesEditor.vue
+++ b/src/renderer/components/notes/NotesEditor.vue
@@ -10,6 +10,7 @@ import {
   useNotesEditor,
   useTheme,
 } from '@/composables'
+import { ipc } from '@/electron'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { indentUnit } from '@codemirror/language'
@@ -31,6 +32,7 @@ import {
   insertHorizontalRule,
   insertLink,
   insertTable,
+  normalizeLineBreaks,
   setBody,
   setHeading,
   toggleBold,
@@ -540,6 +542,15 @@ function onMenuCommand(command: EditorMenuCommand) {
   }
 }
 
+function onNormalizeLineBreaks() {
+  if (!view || isPreviewMode.value)
+    return
+
+  normalizeLineBreaks(view)
+}
+
+ipc.on('main-menu:normalize-note-line-breaks', onNormalizeLineBreaks)
+
 onMounted(() => {
   if (!editorContainer.value)
     return
@@ -556,6 +567,7 @@ onMounted(() => {
 onUnmounted(() => {
   unregisterNavigationNoteUIState?.()
   unregisterNavigationNoteUIState = undefined
+  ipc.removeListeners('main-menu:normalize-note-line-breaks')
 
   if (view) {
     view.destroy()

--- a/src/renderer/components/notes/cm-extensions/__tests__/editorCommands.test.ts
+++ b/src/renderer/components/notes/cm-extensions/__tests__/editorCommands.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest'
 import {
   clearInlineFormatting,
   insertTable,
+  normalizeLineBreaks,
   toggleBulletList,
   toggleOrderedList,
   toggleTaskList,
@@ -71,6 +72,97 @@ describe('editorCommands lists', () => {
     )
 
     expect(result.doc).toBe(['- first', '', '- second'].join('\n'))
+  })
+})
+
+function runNormalizeLineBreaks(
+  doc: string,
+  selection: EditorSelection | { anchor: number, head?: number },
+) {
+  let state = EditorState.create({ doc, selection })
+  let dispatchCount = 0
+  let focusCount = 0
+  const view = {
+    get state() {
+      return state
+    },
+    dispatch(...specs: TransactionSpec[]) {
+      dispatchCount += 1
+      state = state.update(...specs).state
+    },
+    focus() {
+      focusCount += 1
+    },
+  } as EditorView
+
+  normalizeLineBreaks(view)
+
+  return {
+    anchor: state.selection.main.anchor,
+    dispatchCount,
+    doc: state.doc.toString(),
+    focusCount,
+    head: state.selection.main.head,
+  }
+}
+
+describe('editorCommands normalizeLineBreaks', () => {
+  it('normalizes only the selected text and keeps the outside untouched', () => {
+    const doc = 'before\n  wrapped\n  text\nafter'
+    const from = doc.indexOf('  wrapped')
+    const to = doc.indexOf('\nafter')
+
+    expect(
+      runNormalizeLineBreaks(doc, EditorSelection.range(from, to)),
+    ).toEqual({
+      anchor: from,
+      dispatchCount: 1,
+      doc: 'before\nwrapped text\nafter',
+      focusCount: 1,
+      head: from + 'wrapped text'.length,
+    })
+  })
+
+  it('preserves a backward selection direction', () => {
+    const doc = 'before\n  wrapped\n  text\nafter'
+    const from = doc.indexOf('  wrapped')
+    const to = doc.indexOf('\nafter')
+    const replacementEnd = from + 'wrapped text'.length
+
+    expect(
+      runNormalizeLineBreaks(doc, EditorSelection.range(to, from)),
+    ).toEqual({
+      anchor: replacementEnd,
+      dispatchCount: 1,
+      doc: 'before\nwrapped text\nafter',
+      focusCount: 1,
+      head: from,
+    })
+  })
+
+  it('normalizes the whole document and maps the cursor at a line boundary', () => {
+    expect(runNormalizeLineBreaks('first\nsecond', { anchor: 6 })).toEqual({
+      anchor: 6,
+      dispatchCount: 1,
+      doc: 'first second',
+      focusCount: 1,
+      head: 6,
+    })
+  })
+
+  it('only focuses and preserves selection when text is unchanged', () => {
+    expect(
+      runNormalizeLineBreaks(
+        'already normalized',
+        EditorSelection.range(0, 'already normalized'.length),
+      ),
+    ).toEqual({
+      anchor: 0,
+      dispatchCount: 0,
+      doc: 'already normalized',
+      focusCount: 1,
+      head: 'already normalized'.length,
+    })
   })
 })
 

--- a/src/renderer/components/notes/cm-extensions/editorCommands.ts
+++ b/src/renderer/components/notes/cm-extensions/editorCommands.ts
@@ -1,5 +1,9 @@
 import type { ChangeSpec, TransactionSpec } from '@codemirror/state'
 import type { EditorView } from '@codemirror/view'
+import {
+  mapNormalizedCursorIndex,
+  normalizeTerminalText,
+} from '@/utils/normalizeTerminalText'
 import { syntaxTree } from '@codemirror/language'
 import { EditorSelection } from '@codemirror/state'
 import {
@@ -10,6 +14,47 @@ import {
 // Команды редактора заметок, общие для контекстного меню и (в перспективе)
 // хоткеев/тулбара. Каждая функция принимает EditorView, мутирует документ
 // через dispatch и возвращает фокус в редактор.
+
+export function normalizeLineBreaks(view: EditorView) {
+  const { state } = view
+  const main = state.selection.main
+  const from = main.empty ? 0 : main.from
+  const to = main.empty ? state.doc.length : main.to
+  const source = state.doc.sliceString(from, to)
+  const normalized = normalizeTerminalText(source)
+
+  if (normalized === source) {
+    view.focus()
+    return
+  }
+
+  let selection: EditorSelection
+
+  if (main.empty) {
+    const mappedCursor = mapNormalizedCursorIndex(
+      source,
+      main.head,
+      normalized,
+    )
+    selection = EditorSelection.cursor(mappedCursor)
+  }
+  else {
+    const replacementEnd = from + normalized.length
+    const anchor = main.anchor === from ? from : replacementEnd
+    const head = main.head === from ? from : replacementEnd
+    selection = EditorSelection.range(anchor, head)
+  }
+
+  view.dispatch(
+    state.update({
+      changes: { from, to, insert: normalized },
+      selection,
+      scrollIntoView: true,
+      userEvent: 'input',
+    }),
+  )
+  view.focus()
+}
 
 // --- Inline-форматирование -------------------------------------------------
 

--- a/src/renderer/router/index.ts
+++ b/src/renderer/router/index.ts
@@ -17,6 +17,7 @@ export const RouterName = {
   devtoolsCaseConverter: 'devtools/case-converter',
   devtoolsTextToUnicode: 'devtools/text-to-unicode',
   devtoolsTextToAscii: 'devtools/text-to-ascii',
+  devtoolsLineBreakNormalizer: 'devtools/line-break-normalizer',
   devtoolsBase64Converter: 'devtools/base64-converter',
   devtoolsJsonToYaml: 'devtools/json-to-yaml',
   devtoolsJsonToToml: 'devtools/json-to-toml',
@@ -134,6 +135,12 @@ const routes = [
         name: RouterName.devtoolsTextToAscii,
         component: () =>
           import('@/components/devtools/converters/TextToAsciiBinary.vue'),
+      },
+      {
+        path: 'text/line-break-normalizer',
+        name: RouterName.devtoolsLineBreakNormalizer,
+        component: () =>
+          import('@/components/devtools/converters/LineBreakNormalizer.vue'),
       },
       {
         path: 'base64-converter',

--- a/src/renderer/utils/__tests__/normalizeTerminalText.test.ts
+++ b/src/renderer/utils/__tests__/normalizeTerminalText.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+import {
+  mapNormalizedCursorIndex,
+  normalizeTerminalText,
+} from '../normalizeTerminalText'
+
+describe('normalizeTerminalText', () => {
+  it('normalizes copied terminal output into readable paragraphs', () => {
+    const input = `1. Prepare the deployment package. The repository has no release tag, so provide the version explicitly:
+  ./scripts/package.sh 1.4.0
+  The script validates metadata, generates artifacts, and creates a signed archive.
+
+2. Publish the changes:
+  git push --follow-tags
+
+3. Open the dashboard and verify that the new version appears in the release list.`
+
+    expect(normalizeTerminalText(input))
+      .toBe(`1. Prepare the deployment package. The repository has no release tag, so provide the version explicitly:
+
+./scripts/package.sh 1.4.0
+
+The script validates metadata, generates artifacts, and creates a signed archive.
+
+2. Publish the changes:
+
+git push --follow-tags
+
+3. Open the dashboard and verify that the new version appears in the release list.`)
+  })
+
+  it('joins wrapped prose with spaces', () => {
+    expect(normalizeTerminalText('A wrapped\nline with\nwords.')).toBe(
+      'A wrapped line with words.',
+    )
+  })
+
+  it('normalizes CRLF and CR line endings', () => {
+    expect(normalizeTerminalText('first\r\nsecond\rthird')).toBe(
+      'first second third',
+    )
+  })
+
+  it('collapses repeated blank lines between blocks and trims outer blanks', () => {
+    expect(normalizeTerminalText('\n\nfirst\n\n\nsecond\n\n')).toBe(
+      'first\n\nsecond',
+    )
+  })
+
+  it('removes leading and trailing spaces outside fenced blocks', () => {
+    expect(normalizeTerminalText('   first line   \n  second line  ')).toBe(
+      'first line second line',
+    )
+  })
+
+  it('keeps shell commands in separate blocks', () => {
+    const input = `Before
+$ npm test
+> git status
+git status
+../scripts/release.sh
+~/bin/tool
+/usr/bin/env node
+After`
+
+    expect(normalizeTerminalText(input)).toBe(
+      'Before\n\n$ npm test\n\n> git status\n\ngit status\n\n../scripts/release.sh\n\n~/bin/tool\n\n/usr/bin/env node\n\nAfter',
+    )
+  })
+
+  it('keeps tight list items together and joins continuation prose', () => {
+    const input = `1. First item
+continues here
+2) Second item
+also continues
+- Bullet item
+last continuation`
+
+    expect(normalizeTerminalText(input)).toBe(
+      '1. First item continues here\n2) Second item also continues\n- Bullet item last continuation',
+    )
+  })
+
+  it('preserves a GFM table line by line', () => {
+    const input = `| Name | Value |
+| :--- | ---: |
+| first | wrapped |
+| second | value |`
+
+    expect(normalizeTerminalText(input)).toBe(input)
+  })
+
+  it('preserves tight ordered and bullet lists', () => {
+    const input = `1. First
+2. Second
+- Third
+* Fourth`
+
+    expect(normalizeTerminalText(input)).toBe(input)
+  })
+
+  it('preserves indentation for nested list items', () => {
+    const input = `- Parent
+  - Nested with two spaces
+    - Nested with four spaces`
+
+    expect(normalizeTerminalText(input)).toBe(input)
+  })
+
+  it('treats an indented list marker without a parent list as code', () => {
+    const input = `    - literal
+      continuation`
+    const normalized = normalizeTerminalText(input)
+
+    expect(normalized).toBe(input)
+    expect(normalizeTerminalText(normalized)).toBe(normalized)
+  })
+
+  it('preserves tab-indented and four-space indented code', () => {
+    const input = [
+      'Before',
+      '\tconst tabbed = true',
+      '    const spaced = true',
+      'After',
+    ].join('\n')
+
+    expect(normalizeTerminalText(input)).toBe(
+      'Before\n\n\tconst tabbed = true\n    const spaced = true\n\nAfter',
+    )
+  })
+
+  it('preserves multi-line quotes', () => {
+    const input = `> First line
+> second line
+> third line`
+
+    expect(normalizeTerminalText(input)).toBe(input)
+  })
+
+  it('treats command-like lines prefixed with > as a quote sequence', () => {
+    const input = `> git status
+> npm test`
+
+    expect(normalizeTerminalText(input)).toBe(input)
+  })
+
+  it('preserves backtick fenced blocks except for line endings', () => {
+    const input
+      = 'Before\r\n```sh\r\n  echo one\r\n\r\n echo two\r\n```\r\nAfter'
+
+    expect(normalizeTerminalText(input)).toBe(
+      'Before\n\n```sh\n  echo one\n\n echo two\n```\n\nAfter',
+    )
+  })
+
+  it('preserves tilde fenced blocks', () => {
+    const input = '~~~ text\n  one\n two\n~~~~'
+
+    expect(normalizeTerminalText(input)).toBe(input)
+  })
+
+  it('preserves an unmatched fence through the end of the input', () => {
+    const input = 'Intro\n```sh\n  echo one\n\n  echo two'
+
+    expect(normalizeTerminalText(input)).toBe(
+      'Intro\n\n```sh\n  echo one\n\n  echo two',
+    )
+  })
+
+  it('returns an empty string for empty or whitespace-only input', () => {
+    expect(normalizeTerminalText('')).toBe('')
+    expect(normalizeTerminalText(' \n\t\n')).toBe('')
+  })
+
+  it('is idempotent', () => {
+    const input = `1. Run this command:
+  pnpm test
+  Then inspect the result.
+
+~~~sh
+  echo preserved
+~~~`
+    const normalized = normalizeTerminalText(input)
+
+    expect(normalizeTerminalText(normalized)).toBe(normalized)
+  })
+
+  it('is idempotent for mixed markdown', () => {
+    const input = `# Release
+Wrapped prose
+continues here
+
+- First item
+  - Nested item
+second line of nested item
+
+> Quote one
+> Quote two
+
+    pnpm test
+
+| Name | Value |
+| --- | --- |
+| one | two |`
+    const normalized = normalizeTerminalText(input)
+
+    expect(normalizeTerminalText(normalized)).toBe(normalized)
+  })
+
+  it('keeps markdown structural lines in separate blocks', () => {
+    expect(normalizeTerminalText('# Heading\nText\n> Quote\n---')).toBe(
+      '# Heading\n\nText\n\n> Quote\n\n---',
+    )
+  })
+
+  it('maps a cursor using the normalized suffix at paragraph boundaries', () => {
+    const prose = 'first\nsecond'
+    const command = 'Before\ngit status'
+
+    expect(mapNormalizedCursorIndex(prose, 5)).toBe(5)
+    expect(mapNormalizedCursorIndex(prose, 6)).toBe(6)
+    expect(mapNormalizedCursorIndex(command, 'Before\n'.length)).toBe(
+      'Before\n\n'.length,
+    )
+  })
+
+  it('falls back to prefix mapping inside a fenced block', () => {
+    const input = '```sh\n  first\n  second\n```'
+    const cursorIndex = input.indexOf('second')
+
+    expect(mapNormalizedCursorIndex(input, cursorIndex)).toBe(cursorIndex)
+  })
+})

--- a/src/renderer/utils/normalizeTerminalText.ts
+++ b/src/renderer/utils/normalizeTerminalText.ts
@@ -1,0 +1,237 @@
+const commandNames = [
+  'git',
+  'gh',
+  'npm',
+  'pnpm',
+  'yarn',
+  'bun',
+  'deno',
+  'node',
+  'npx',
+  'bunx',
+  'python',
+  'pip',
+  'cargo',
+  'go',
+  'docker',
+  'kubectl',
+  'xcodebuild',
+  'xcodegen',
+  'make',
+  'cmake',
+  'curl',
+  'wget',
+  'ssh',
+  'rsync',
+]
+
+const commandNamePattern = new RegExp(
+  `^(?:${commandNames.join('|')})(?:\\s|$)`,
+)
+const listMarkerPattern = /^(\s*)(?:[-+*]|\d+[.)])\s+/
+const headingPattern = /^#{1,6}(?:\s+|$)/
+const quotePattern = /^>\s?/
+const horizontalRulePattern = /^(?:(?:\*\s*){3,}|(?:-\s*){3,}|(?:_\s*){3,})$/
+
+type SubBlockKind =
+  | 'code'
+  | 'command'
+  | 'list'
+  | 'plain'
+  | 'quote'
+  | 'structure'
+
+interface SubBlock {
+  kind: SubBlockKind
+  lines: string[]
+}
+
+function isCommandBody(line: string) {
+  return /^(?:\.{1,2}\/|~\/|\/)\S*/.test(line) || commandNamePattern.test(line)
+}
+
+function isShellCommand(line: string) {
+  return /^\$\s+/.test(line) || isCommandBody(line)
+}
+
+function isTableDelimiter(line: string) {
+  const trimmed = line.trim().replace(/^\||\|$/g, '')
+  const cells = trimmed.split('|')
+
+  return (
+    line.includes('|') && cells.every(cell => /^:?-{3,}:?$/.test(cell.trim()))
+  )
+}
+
+function getFenceMarker(line: string) {
+  return line.match(/^\s*(`{3,}|~{3,})/)?.[1]
+}
+
+function isFenceClosingLine(line: string, marker: string) {
+  const markerCharacter = marker[0]
+  const candidate = line.trim()
+
+  return (
+    candidate.length >= marker.length
+    && [...candidate].every(character => character === markerCharacter)
+  )
+}
+
+function pushSubBlock(blocks: SubBlock[], kind: SubBlockKind, line: string) {
+  const previous = blocks.at(-1)
+
+  if (previous?.kind === kind && ['code', 'quote'].includes(kind)) {
+    previous.lines.push(line)
+    return
+  }
+
+  blocks.push({ kind, lines: [line] })
+}
+
+function normalizeChunk(lines: string[]) {
+  if (lines.some(isTableDelimiter))
+    return lines.join('\n')
+
+  const blocks: SubBlock[] = []
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    const listMatch = rawLine.match(listMarkerPattern)
+    const previous = blocks.at(-1)
+
+    if (/^(?:\t| {4,})/.test(rawLine)) {
+      if (previous?.kind === 'list') {
+        previous.lines.push(rawLine)
+      }
+      else {
+        pushSubBlock(blocks, 'code', rawLine)
+      }
+      continue
+    }
+
+    if (listMatch) {
+      const normalizedLine = `${listMatch[1]}${rawLine
+        .slice(listMatch[1].length)
+        .trim()}`
+      if (previous?.kind === 'list') {
+        previous.lines.push(normalizedLine)
+      }
+      else {
+        blocks.push({ kind: 'list', lines: [normalizedLine] })
+      }
+      continue
+    }
+
+    if (isShellCommand(line)) {
+      blocks.push({ kind: 'command', lines: [line] })
+      continue
+    }
+
+    if (quotePattern.test(line)) {
+      pushSubBlock(blocks, 'quote', line)
+      continue
+    }
+
+    if (headingPattern.test(line) || horizontalRulePattern.test(line)) {
+      blocks.push({ kind: 'structure', lines: [line] })
+      continue
+    }
+
+    if (previous?.kind === 'list') {
+      const lastIndex = previous.lines.length - 1
+      previous.lines[lastIndex] = `${previous.lines[lastIndex]} ${line}`
+      continue
+    }
+
+    if (previous?.kind === 'plain') {
+      previous.lines.push(line)
+    }
+    else {
+      blocks.push({ kind: 'plain', lines: [line] })
+    }
+  }
+
+  return blocks
+    .map((block) => {
+      if (block.kind === 'plain')
+        return block.lines.join(' ')
+
+      return block.lines.join('\n')
+    })
+    .join('\n\n')
+}
+
+export function normalizeTerminalText(value: string) {
+  const lines = value.replace(/\r\n?/g, '\n').split('\n')
+  const blocks: string[] = []
+  let chunk: string[] = []
+
+  function flushChunk() {
+    if (!chunk.length)
+      return
+
+    blocks.push(normalizeChunk(chunk))
+    chunk = []
+  }
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const rawLine = lines[index]
+    const fenceMarker = getFenceMarker(rawLine)
+
+    if (fenceMarker) {
+      flushChunk()
+      const fenceLines = [rawLine]
+
+      while (index + 1 < lines.length) {
+        index += 1
+        const fenceLine = lines[index]
+        fenceLines.push(fenceLine)
+
+        if (isFenceClosingLine(fenceLine, fenceMarker))
+          break
+      }
+
+      blocks.push(fenceLines.join('\n'))
+      continue
+    }
+
+    if (!rawLine.trim()) {
+      flushChunk()
+      continue
+    }
+
+    chunk.push(rawLine)
+  }
+
+  flushChunk()
+
+  return blocks.join('\n\n')
+}
+
+export function mapNormalizedCursorIndex(
+  value: string,
+  cursorIndex: number,
+  normalized = normalizeTerminalText(value),
+) {
+  const index = Math.min(Math.max(cursorIndex, 0), value.length)
+
+  if (value[index] === '\n' || value[index] === '\r') {
+    return Math.min(
+      normalizeTerminalText(value.slice(0, index)).length,
+      normalized.length,
+    )
+  }
+
+  const normalizedSuffix = normalizeTerminalText(value.slice(index))
+
+  if (!normalizedSuffix)
+    return normalized.length
+
+  if (normalized.endsWith(normalizedSuffix))
+    return normalized.length - normalizedSuffix.length
+
+  return Math.min(
+    normalizeTerminalText(value.slice(0, index)).length,
+    normalized.length,
+  )
+}

--- a/src/renderer/views/Devtools.vue
+++ b/src/renderer/views/Devtools.vue
@@ -31,6 +31,10 @@ const convertersNav = [
     name: RouterName.devtoolsTextToAscii,
   },
   {
+    label: i18n.t('devtools:converters.lineBreakNormalizer.label'),
+    name: RouterName.devtoolsLineBreakNormalizer,
+  },
+  {
     label: i18n.t('devtools:converters.base64.label'),
     name: RouterName.devtoolsBase64Converter,
   },


### PR DESCRIPTION
## Summary

- normalize hard-wrapped terminal text while preserving Markdown structure and code blocks
- add the action to the Editor menu for Code and Notes, with selection and cursor preservation
- add a localized Line Break Normalizer converter to Dev Tools

## Tests

- pnpm test -- src/renderer/utils/__tests__/normalizeTerminalText.test.ts src/renderer/components/notes/cm-extensions/__tests__/editorCommands.test.ts src/main/menu/__tests__/main.test.ts — 47 tests passed