### PR TITLE
fix(notes): prevent fenced code height jump

### DIFF
--- a/src/renderer/components/notes/cm-extensions/__tests__/hideMarkup.test.ts
+++ b/src/renderer/components/notes/cm-extensions/__tests__/hideMarkup.test.ts
@@ -3,10 +3,12 @@ import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { syntaxTree } from '@codemirror/language'
 import { languages } from '@codemirror/language-data'
 import { EditorState } from '@codemirror/state'
+import { Decoration } from '@codemirror/view'
 import { GFM } from '@lezer/markdown'
 import { describe, expect, it } from 'vitest'
 import {
   canShowMarkup,
+  createMarkupHidingDecoration,
   shouldHideUrlNodeInMarkup,
   shouldKeepStandaloneFencedCodeMarkup,
 } from '../hideMarkup'
@@ -67,6 +69,29 @@ describe('standalone fenced code markup visibility', () => {
         shouldKeepStandaloneFencedCodeMarkup(node.name, node.parent),
       ),
     ).toEqual([false, false, false])
+  })
+})
+
+describe('fenced code markup hiding decoration', () => {
+  it.each(['CodeMark', 'CodeInfo'])(
+    'hides %s without inserting a replacement widget buffer',
+    (nodeName) => {
+      const decoration = createMarkupHidingDecoration(nodeName, 'FencedCode')
+
+      expect(
+        decoration.eq(
+          Decoration.mark({
+            attributes: { style: 'visibility:hidden' },
+          }),
+        ),
+      ).toBe(true)
+    },
+  )
+
+  it('keeps replacement decorations for markup outside fenced code', () => {
+    const decoration = createMarkupHidingDecoration('EmphasisMark', 'Emphasis')
+
+    expect(decoration.eq(Decoration.replace({}))).toBe(true)
   })
 })
 

--- a/src/renderer/components/notes/cm-extensions/hideMarkup.ts
+++ b/src/renderer/components/notes/cm-extensions/hideMarkup.ts
@@ -49,6 +49,22 @@ export function shouldKeepStandaloneFencedCodeMarkup(
   )
 }
 
+export function createMarkupHidingDecoration(
+  nodeName: string,
+  parentName: string | null | undefined,
+): Decoration {
+  if (
+    (nodeName === 'CodeMark' || nodeName === 'CodeInfo')
+    && parentName === 'FencedCode'
+  ) {
+    return Decoration.mark({
+      attributes: { style: 'visibility:hidden' },
+    })
+  }
+
+  return Decoration.replace({})
+}
+
 function isInternalLinkBracket(
   view: EditorView,
   node: { name: string, from: number, to: number },
@@ -154,7 +170,12 @@ function buildHideDecorations(view: EditorView, alwaysHide: boolean) {
             end = node.to + 1
         }
 
-        decorations.push(Decoration.replace({}).range(node.from, end))
+        decorations.push(
+          createMarkupHidingDecoration(node.name, node.node.parent?.name).range(
+            node.from,
+            end,
+          ),
+        )
       },
     })
   }


### PR DESCRIPTION
Preserve fenced-code markup metrics while hidden to prevent the editor block from changing height when raw markup is revealed. Keep replacement decorations for other Markdown markup and cover both paths with focused tests.