### PR TITLE
feat(notes): add code block copy badge

### DIFF
--- a/src/renderer/components/notes/NotesEditor.vue
+++ b/src/renderer/components/notes/NotesEditor.vue
@@ -7,10 +7,11 @@ import * as ContextMenu from '@/components/ui/shadcn/context-menu'
 import {
   applyPendingNavigationUIStateForNote,
   registerNavigationNoteUIState,
+  useCopyToClipboard,
   useNotesEditor,
   useTheme,
 } from '@/composables'
-import { ipc } from '@/electron'
+import { i18n, ipc } from '@/electron'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { indentUnit } from '@codemirror/language'
@@ -88,6 +89,7 @@ const props = withDefaults(defineProps<Props>(), {
 const content = defineModel<string>('content', { default: '' })
 const { isDark } = useTheme()
 const { settings: notesSettings } = useNotesEditor()
+const copyToClipboard = useCopyToClipboard()
 const isRawMode = computed(() => props.mode === 'raw')
 const isPreviewMode = computed(() => props.mode === 'preview')
 
@@ -271,6 +273,10 @@ function createEditorState(doc: string): EditorState {
       createMarkdownDecorations({
         interactiveTaskMarkers: editable,
         calloutTitleMode: preview ? 'replace' : 'smart',
+        codeBlockCopy: {
+          label: i18n.t('button.copy'),
+          copy: copyToClipboard,
+        },
       }),
       createHideMarkup({ alwaysHide: preview }),
       createListLineIndent({ interactiveTaskMarkers: editable }),

--- a/src/renderer/components/notes/cm-extensions/__tests__/codeBlockCopy.test.ts
+++ b/src/renderer/components/notes/cm-extensions/__tests__/codeBlockCopy.test.ts
@@ -1,0 +1,88 @@
+import type { VNode } from 'vue'
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
+import { syntaxTree } from '@codemirror/language'
+import { EditorState } from '@codemirror/state'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  configureCodeBlockCopyRoot,
+  createCodeBlockCopyControl,
+  getFencedCodeContent,
+} from '../codeBlockCopy'
+
+function getContent(doc: string) {
+  const state = EditorState.create({
+    doc,
+    extensions: [markdown({ base: markdownLanguage })],
+  })
+  const fencedCode = syntaxTree(state).topNode.getChild('FencedCode')
+
+  if (!fencedCode)
+    throw new Error('Expected fenced code block')
+
+  return getFencedCodeContent(state, fencedCode)
+}
+
+describe('getFencedCodeContent', () => {
+  it('extracts the language token and only CodeText from a fenced block', () => {
+    expect(
+      getContent('~~~typescript title=example\nconst value = 1\n~~~'),
+    ).toEqual({
+      language: 'typescript',
+      code: 'const value = 1',
+    })
+  })
+
+  it('returns an empty language without including fences in copied code', () => {
+    expect(getContent('~~~\nline 1\nline 2\n~~~')).toEqual({
+      language: '',
+      code: 'line 1\nline 2',
+    })
+  })
+
+  it('supports an empty fenced block', () => {
+    expect(getContent('~~~\n~~~')).toEqual({
+      language: '',
+      code: '',
+    })
+  })
+})
+
+describe('code block copy control', () => {
+  it('uses the project tooltip without a native title', () => {
+    const control = createCodeBlockCopyControl(
+      { language: 'ts', code: 'const value = 1' },
+      { label: 'Copy', copy: vi.fn() },
+    )
+    const slots = control.children as { default: () => VNode }
+    const actionButton = slots.default()
+
+    expect(actionButton.props.tooltip).toBe('Copy')
+    expect(actionButton.props['aria-label']).toBe('Copy')
+    expect(actionButton.props.title).toBeUndefined()
+  })
+
+  it('marks the widget root and control as non-selectable', () => {
+    const root = {
+      className: '',
+      contentEditable: '',
+      style: {},
+    } as unknown as HTMLElement
+
+    configureCodeBlockCopyRoot(root)
+
+    expect(root.contentEditable).toBe('false')
+    expect(root.style.userSelect).toBe('none')
+
+    const control = createCodeBlockCopyControl(
+      { language: '', code: '' },
+      { label: 'Copy', copy: vi.fn() },
+    )
+    const slots = control.children as { default: () => VNode }
+    const actionButton = slots.default()
+    expect(actionButton.props.contenteditable).toBe(false)
+    expect(actionButton.props.class).toContain('select-none')
+    expect(actionButton.props.class).toContain('h-6')
+    expect(actionButton.props.class).toContain('leading-3')
+    expect(actionButton.props.class).not.toContain('cursor-pointer')
+  })
+})

--- a/src/renderer/components/notes/cm-extensions/codeBlockCopy.ts
+++ b/src/renderer/components/notes/cm-extensions/codeBlockCopy.ts
@@ -1,0 +1,115 @@
+import type { EditorState } from '@codemirror/state'
+import type { EditorView } from '@codemirror/view'
+import type { SyntaxNode } from '@lezer/common'
+import type { VNode } from 'vue'
+import ActionButton from '@/components/ui/action-button/ActionButton.vue'
+import { TooltipProvider } from '@/components/ui/shadcn/tooltip'
+import { WidgetType } from '@codemirror/view'
+import { Copy } from 'lucide-vue-next'
+import { h, render } from 'vue'
+
+export interface CodeBlockCopyOptions {
+  label: string
+  copy: (code: string) => void
+}
+
+export interface FencedCodeContent {
+  code: string
+  language: string
+}
+
+export function getFencedCodeContent(
+  state: EditorState,
+  node: SyntaxNode,
+): FencedCodeContent {
+  const codeInfo = node.getChild('CodeInfo')
+  const codeText = node.getChild('CodeText')
+  const info = codeInfo
+    ? state.sliceDoc(codeInfo.from, codeInfo.to).trim()
+    : ''
+
+  return {
+    language: info.split(/\s+/, 1)[0] ?? '',
+    code: codeText ? state.sliceDoc(codeText.from, codeText.to) : '',
+  }
+}
+
+export function configureCodeBlockCopyRoot(root: HTMLElement): void {
+  root.className = 'cm-code-block-copy'
+  root.contentEditable = 'false'
+  root.style.position = 'absolute'
+  root.style.top = '6px'
+  root.style.right = '12px'
+  root.style.zIndex = '1'
+  root.style.userSelect = 'none'
+}
+
+export function createCodeBlockCopyControl(
+  content: FencedCodeContent,
+  options: CodeBlockCopyOptions,
+): VNode {
+  const onMouseDown = (event: MouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+  }
+  const onClick = (event: MouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    options.copy(content.code)
+  }
+
+  return h(TooltipProvider, null, {
+    default: () =>
+      h(
+        ActionButton,
+        {
+          'aria-label': options.label,
+          'class': [
+            'border-border bg-background h-6 select-none rounded-md border font-mono text-[11px] leading-3 font-normal',
+            content.language ? 'px-2' : 'w-6 px-0',
+          ],
+          'contenteditable': false,
+          'size': content.language ? 'iconText' : 'icon',
+          'tooltip': options.label,
+          'onMousedown': onMouseDown,
+          'onClick': onClick,
+        },
+        {
+          default: () => content.language || h(Copy, { 'aria-hidden': 'true' }),
+        },
+      ),
+  })
+}
+
+export class CodeBlockCopyWidget extends WidgetType {
+  constructor(
+    readonly content: FencedCodeContent,
+    readonly options: CodeBlockCopyOptions,
+  ) {
+    super()
+  }
+
+  eq(other: CodeBlockCopyWidget): boolean {
+    return (
+      this.content.code === other.content.code
+      && this.content.language === other.content.language
+      && this.options.label === other.options.label
+      && this.options.copy === other.options.copy
+    )
+  }
+
+  toDOM(_view: EditorView): HTMLElement {
+    const root = document.createElement('span')
+    configureCodeBlockCopyRoot(root)
+    render(createCodeBlockCopyControl(this.content, this.options), root)
+    return root
+  }
+
+  destroy(dom: HTMLElement): void {
+    render(null, dom)
+  }
+
+  ignoreEvent(): boolean {
+    return true
+  }
+}

--- a/src/renderer/components/notes/cm-extensions/fencedCodeStyles.ts
+++ b/src/renderer/components/notes/cm-extensions/fencedCodeStyles.ts
@@ -30,7 +30,7 @@ export function buildFencedCodeLineStyle(
 
   if (lineNumber === startLineNumber) {
     style
-      += ';border-top:1px solid var(--border);border-top-left-radius:8px;border-top-right-radius:8px;padding-top:10px'
+      += ';position:relative;border-top:1px solid var(--border);border-top-left-radius:8px;border-top-right-radius:8px;padding-top:10px'
   }
 
   if (lineNumber === endLineNumber) {

--- a/src/renderer/components/notes/cm-extensions/markdownDecorations.ts
+++ b/src/renderer/components/notes/cm-extensions/markdownDecorations.ts
@@ -11,6 +11,11 @@ import {
   shouldReplaceCalloutMarker,
 } from './callouts'
 import {
+  type CodeBlockCopyOptions,
+  CodeBlockCopyWidget,
+  getFencedCodeContent,
+} from './codeBlockCopy'
+import {
   buildFencedCodeLineStyle,
   isStandaloneFencedCode,
 } from './fencedCodeStyles'
@@ -281,6 +286,7 @@ function getCalloutBlockquoteStyle(type: CalloutType) {
 interface MarkdownDecorationsOptions {
   interactiveTaskMarkers?: boolean
   calloutTitleMode?: CalloutTitleMode
+  codeBlockCopy?: CodeBlockCopyOptions
 }
 
 interface MarkdownDecorationsUpdateFlags {
@@ -400,6 +406,7 @@ function buildDecorations(
   view: EditorView,
   interactiveTaskMarkers: boolean,
   calloutTitleMode: CalloutTitleMode,
+  codeBlockCopy?: CodeBlockCopyOptions,
 ) {
   const decorations: Range<Decoration>[] = []
 
@@ -486,6 +493,18 @@ function buildDecorations(
 
           const startLine = view.state.doc.lineAt(node.from)
           const endLine = view.state.doc.lineAt(node.to)
+
+          if (codeBlockCopy) {
+            decorations.push(
+              Decoration.widget({
+                widget: new CodeBlockCopyWidget(
+                  getFencedCodeContent(view.state, node.node),
+                  codeBlockCopy,
+                ),
+                side: 1,
+              }).range(startLine.to),
+            )
+          }
 
           for (let i = startLine.number; i <= endLine.number; i++) {
             const line = view.state.doc.line(i)
@@ -649,7 +668,11 @@ function buildDecorations(
 export function createMarkdownDecorations(
   options: MarkdownDecorationsOptions = {},
 ) {
-  const { interactiveTaskMarkers = true, calloutTitleMode = 'smart' } = options
+  const {
+    interactiveTaskMarkers = true,
+    calloutTitleMode = 'smart',
+    codeBlockCopy,
+  } = options
 
   return ViewPlugin.fromClass(
     class {
@@ -660,6 +683,7 @@ export function createMarkdownDecorations(
           view,
           interactiveTaskMarkers,
           calloutTitleMode,
+          codeBlockCopy,
         )
       }
 
@@ -680,6 +704,7 @@ export function createMarkdownDecorations(
             update.view,
             interactiveTaskMarkers,
             calloutTitleMode,
+            codeBlockCopy,
           )
         }
       }


### PR DESCRIPTION
Adds a copy control to fenced code blocks in Notes: the detected language is shown as a badge, blocks without a language use a copy icon, and the project tooltip is used. The control is non-selectable, keeps the default cursor, and uses stable text metrics. Verified with 27 scoped tests and scoped ESLint.