### PR TITLE
fix(notes): reset preview scroll on note switch

### DIFF
--- a/src/renderer/components/notes/NotesEditor.vue
+++ b/src/renderer/components/notes/NotesEditor.vue
@@ -417,7 +417,20 @@ async function syncNavigationNoteUIStateRegistration(noteId = props.noteId) {
   })
 
   await nextTick()
-  applyPendingNavigationUIStateForNote(noteId)
+
+  // Пока ожидали обновление DOM, пользователь мог выбрать другую заметку.
+  if (!view || props.noteId !== noteId) {
+    return
+  }
+
+  // Back/Forward восстанавливает сохранённую позицию. При обычном выборе
+  // новая заметка открывается сверху. Эффект CodeMirror также пересчитывает
+  // viewport, чтобы preview-декорации сразу построились для начала документа.
+  if (!applyPendingNavigationUIStateForNote(noteId)) {
+    view.dispatch({
+      effects: EditorView.scrollIntoView(0, { y: 'start', yMargin: 0 }),
+    })
+  }
 }
 
 watch(


### PR DESCRIPTION
## Summary
- reset newly selected notes to the top in preview mode
- preserve saved scroll restoration for Back/Forward navigation
- force CodeMirror viewport recomputation so preview decorations render immediately
- ignore stale work after rapid note switches

## Testing
- pnpm -s eslint src/renderer/components/notes/NotesEditor.vue
- pnpm -s test src/renderer/composables/__tests__/useNavigationUIState.test.ts src/renderer/components/notes/__tests__/editorSync.test.ts
- git diff --check