### PR TITLE
feat: move Notes assets to managed storage

### DIFF
--- a/docs/website/documentation/notes/images.md
+++ b/docs/website/documentation/notes/images.md
@@ -7,7 +7,7 @@ description: "Embed images in massCode Notes with standard markdown syntax, past
 
 Use images when a screenshot, diagram, or visual reference belongs next to the note text.
 
-Images are rendered directly inside your note from standard markdown image syntax. For local images, paste an image from the clipboard or drag an image file into the editor. massCode saves the file to `notes/assets` in your vault and inserts the markdown for you.
+Images are rendered directly inside your note from standard markdown image syntax. For local images, paste an image from the clipboard or drag an image file into the editor. massCode saves new files to `notes/.masscode/assets` in your vault and inserts the markdown for you.
 
 ```md
 ![image-name](masscode://notes-asset/generated-file-name.png)
@@ -19,7 +19,11 @@ You can also use a remote image URL:
 ![Remote screenshot](https://example.com/screenshot.png)
 ```
 
+The `masscode://notes-asset/` URL is resolved by massCode. Other Markdown apps may not display these local images directly. When you copy or synchronize Notes between devices, include the whole vault, including the hidden `notes/.masscode` directory. Copying only Markdown files leaves their local images behind.
+
+Vaults with images in the managed `notes/.masscode/assets` path require a massCode version that supports this layout. Older versions may not display these images.
+
 - Paste or drag images in **Editor** and **Live Preview** modes.
 - View images in **Live Preview** or **Preview** mode.
 - Click an image block in editable modes to reveal and edit its markdown source.
-- Supported pasted and dropped formats: `png`, `jpg`, `jpeg`, `gif`, `webp`, `svg`, and `bmp`.
+- New pasted and dropped images can use `png`, `jpg`, or `jpeg`.

--- a/src/main/i18n/locales/en_US/preferences.json
+++ b/src/main/i18n/locales/en_US/preferences.json
@@ -45,6 +45,24 @@
         "invalid-frontmatter": "Invalid frontmatter",
         "conflicted-copy": "Conflicted copy"
       },
+      "assetWarnings": {
+        "NOTES_LEGACY_ASSET": {
+          "message": "{{assetName}} is still stored in the legacy Notes assets folder.",
+          "recommendation": "Keep the whole vault synchronized and scan again after migration completes."
+        },
+        "NOTES_ASSET_MIGRATION_PENDING": {
+          "message": "{{assetName}} is not available locally for migration inspection.",
+          "recommendation": "Make the asset available locally, then scan the vault again."
+        },
+        "NOTES_ASSET_DESTINATION_CONFLICT": {
+          "message": "{{assetName}} differs between the legacy and current Notes assets folders.",
+          "recommendation": "Compare both files and keep the correct copy before removing either one."
+        },
+        "NOTES_ASSET_MISSING": {
+          "message": "{{assetName}} is missing from both Notes assets folders.",
+          "recommendation": "Restore the asset to the vault or remove its reference from the note."
+        }
+      },
       "moreWarnings": "+{{count}} more warnings",
       "warnings": "Warnings"
     }

--- a/src/main/i18n/locales/ru_RU/preferences.json
+++ b/src/main/i18n/locales/ru_RU/preferences.json
@@ -43,6 +43,24 @@
         "invalid-frontmatter": "Битый frontmatter",
         "conflicted-copy": "Конфликтная копия"
       },
+      "assetWarnings": {
+        "NOTES_LEGACY_ASSET": {
+          "message": "{{assetName}} всё ещё хранится в старой папке изображений Notes.",
+          "recommendation": "Синхронизируйте vault целиком и повторите проверку после завершения миграции."
+        },
+        "NOTES_ASSET_MIGRATION_PENDING": {
+          "message": "{{assetName}} недоступен локально для проверки миграции.",
+          "recommendation": "Сделайте файл доступным локально и повторно проверьте vault."
+        },
+        "NOTES_ASSET_DESTINATION_CONFLICT": {
+          "message": "{{assetName}} отличается в старой и текущей папках изображений Notes.",
+          "recommendation": "Сравните оба файла и сохраните правильную копию, прежде чем удалять любой из них."
+        },
+        "NOTES_ASSET_MISSING": {
+          "message": "{{assetName}} отсутствует в обеих папках изображений Notes.",
+          "recommendation": "Восстановите файл в vault или удалите ссылку на него из заметки."
+        }
+      },
       "moreWarnings": "+{{count}} предупреждений",
       "warnings": "Предупреждения"
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable node/prefer-global/process */
-import { readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { app, BrowserWindow, ipcMain, Menu, protocol, screen } from 'electron'
@@ -11,6 +10,11 @@ import { validateStoredLicense } from './license'
 import { createMainMenu } from './menu/main'
 import { isQuitting, setQuitting } from './quitState'
 import { startMarkdownWatcher, stopMarkdownWatcher } from './storage'
+import {
+  getNotesPaths,
+  resolveNotesAsset,
+} from './storage/providers/markdown/notes/runtime'
+import { getVaultPath } from './storage/providers/markdown/runtime/paths'
 import { ensureFlatSpacesLayout } from './storage/providers/markdown/runtime/spaces'
 import { store } from './store'
 import { startTasksCleanupScheduler, stopTasksCleanupScheduler } from './tasks'
@@ -146,37 +150,8 @@ else {
       const url = new URL(request.url)
 
       if (url.hostname === 'notes-asset') {
-        const fileName = url.pathname.replace(/^\//, '')
-        const vaultPath
-          = (store.preferences.get('storage.vaultPath') as string | null)
-            || path.join(
-              store.preferences.get('storage.rootPath') as string,
-              'markdown-vault',
-            )
-        ensureFlatSpacesLayout(vaultPath)
-        const filePath = path.join(vaultPath, 'notes', 'assets', fileName)
-
-        try {
-          const data = await readFile(filePath)
-          const ext = path.extname(fileName).toLowerCase()
-          const mimeTypes: Record<string, string> = {
-            '.png': 'image/png',
-            '.jpg': 'image/jpeg',
-            '.jpeg': 'image/jpeg',
-            '.gif': 'image/gif',
-            '.webp': 'image/webp',
-            '.svg': 'image/svg+xml',
-            '.bmp': 'image/bmp',
-          }
-          return new Response(data, {
-            headers: {
-              'Content-Type': mimeTypes[ext] || 'application/octet-stream',
-            },
-          })
-        }
-        catch {
-          return new Response('Not found', { status: 404 })
-        }
+        const paths = getNotesPaths(getVaultPath())
+        return resolveNotesAsset(url.pathname.replace(/^\//, ''), paths)
       }
 
       return new Response('Not found', { status: 404 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,7 +9,11 @@ import { startThemeWatcher, stopThemeWatcher } from './ipc/handlers/theme'
 import { validateStoredLicense } from './license'
 import { createMainMenu } from './menu/main'
 import { isQuitting, setQuitting } from './quitState'
-import { startMarkdownWatcher, stopMarkdownWatcher } from './storage'
+import {
+  prepareMarkdownWatcher,
+  startMarkdownWatcher,
+  stopMarkdownWatcher,
+} from './storage'
 import {
   getNotesPaths,
   resolveNotesAsset,
@@ -224,6 +228,13 @@ else {
     }
     catch (error) {
       log('Error registering IPC', error)
+    }
+
+    try {
+      prepareMarkdownWatcher()
+    }
+    catch (error) {
+      log('Error preparing markdown watcher', error)
     }
 
     try {

--- a/src/main/ipc/handlers/fs.ts
+++ b/src/main/ipc/handlers/fs.ts
@@ -12,6 +12,11 @@ import {
   writeFileSync,
 } from 'fs-extra'
 import slash from 'slash'
+import {
+  getNotesPaths,
+  parseNotesAssetWritePayload,
+  writeNotesAsset,
+} from '../../storage/providers/markdown/notes/runtime'
 import { ensureFlatSpacesLayout } from '../../storage/providers/markdown/runtime/spaces'
 import { store } from '../../store'
 
@@ -118,7 +123,12 @@ export function registerFsHandlers() {
     })
   })
 
-  ipcMain.handle('fs:notes-asset', (event, { buffer, ext }) => {
+  ipcMain.handle('fs:notes-asset', async (event, payload: unknown) => {
+    const parsedPayload = parseNotesAssetWritePayload(payload)
+    if (!parsedPayload) {
+      throw new TypeError('Invalid Notes asset payload')
+    }
+
     const vaultPath
       = (store.preferences.get('storage.vaultPath') as string | null)
         || join(
@@ -126,22 +136,12 @@ export function registerFsHandlers() {
           'markdown-vault',
         )
 
-    return new Promise((resolve, reject) => {
-      try {
-        ensureFlatSpacesLayout(vaultPath)
-        const assetsPath = join(vaultPath, 'notes', 'assets')
-        const name = `${generateAssetId()}${ext}`
-        const dest = join(assetsPath, name)
-
-        ensureDirSync(assetsPath)
-        writeFileSync(dest, Buffer.from(buffer))
-
-        resolve(`masscode://notes-asset/${name}`)
-      }
-      catch (error) {
-        reject(error)
-      }
-    })
+    ensureFlatSpacesLayout(vaultPath)
+    return writeNotesAsset(
+      getNotesPaths(vaultPath),
+      parsedPayload.buffer,
+      parsedPayload.ext,
+    )
   })
 
   ipcMain.handle('fs:import-markdown-folder', async () => {

--- a/src/main/storage/index.ts
+++ b/src/main/storage/index.ts
@@ -5,6 +5,7 @@ import type {
 } from './contracts'
 import {
   createMarkdownStorageProvider,
+  prepareMarkdownWatcher,
   startMarkdownWatcher,
   stopMarkdownWatcher,
 } from './providers/markdown'
@@ -27,4 +28,4 @@ export function useHttpStorage(): HttpStorageProvider {
   return httpStorageProvider
 }
 
-export { startMarkdownWatcher, stopMarkdownWatcher }
+export { prepareMarkdownWatcher, startMarkdownWatcher, stopMarkdownWatcher }

--- a/src/main/storage/providers/markdown/__tests__/doctor.test.ts
+++ b/src/main/storage/providers/markdown/__tests__/doctor.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import os from 'node:os'
 import path from 'node:path'
 import fs from 'fs-extra'
@@ -6,7 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { applyVaultDoctor, previewVaultDoctor } from '../doctor'
 import { resetHttpRuntimeCache } from '../http/runtime'
 import { resetNotesRuntimeCache } from '../notes/runtime'
+import { waitForNotesAssetsMigrationForTests } from '../notes/runtime/assetsMigration'
 import { resetRuntimeCache } from '../runtime'
+import { setDatalessProbeForTests } from '../runtime/shared/cloudFiles'
 
 let tempVaultPath = ''
 
@@ -58,6 +61,9 @@ vi.mock('electron', () => ({
   app: {
     getPath: () => os.tmpdir(),
   },
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
 }))
 
 vi.mock('../../../../store', () => ({
@@ -78,6 +84,15 @@ function writeFile(relativePath: string, content: string): void {
   const absolutePath = path.join(tempVaultPath, relativePath)
   fs.ensureDirSync(path.dirname(absolutePath))
   fs.writeFileSync(absolutePath, content, 'utf8')
+}
+
+function writeSparseFile(relativePath: string): string {
+  const absolutePath = path.join(tempVaultPath, relativePath)
+  fs.ensureDirSync(path.dirname(absolutePath))
+  const descriptor = fs.openSync(absolutePath, 'w')
+  fs.ftruncateSync(descriptor, 4096)
+  fs.closeSync(descriptor)
+  return absolutePath
 }
 
 function snippetSource(id: number, name: string): string {
@@ -101,6 +116,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  setDatalessProbeForTests(null)
   resetRuntimeCache()
   resetNotesRuntimeCache()
   resetHttpRuntimeCache()
@@ -154,6 +170,212 @@ describe('vault doctor', () => {
     )
     expect(danglingWarnings).toHaveLength(1)
     expect(danglingWarnings[0].path).toBe('Dangling.md')
+  })
+
+  it('audits only referenced notes assets without changing their bytes', () => {
+    const legacyName = 'abcdefghijklmnop.png'
+    const equalName = 'ponmlkjihgfedcba.jpg'
+    const conflictName = 'abcdefghijklmnopqrstu.jpeg'
+    const missingName = 'ponmlkjihgfedcbazyxwv.png'
+    const healthyName = 'qrstuvwxyzabcdef.jpg'
+    const unknownName = 'zyxwvutsrqponmlk.png'
+
+    writeFile(`notes/assets/${legacyName}`, 'legacy')
+    writeFile(`notes/assets/${equalName}`, 'equal')
+    writeFile(`notes/.masscode/assets/${equalName}`, 'equal')
+    writeFile(`notes/assets/${conflictName}`, 'source')
+    writeFile(`notes/.masscode/assets/${conflictName}`, 'destination')
+    writeFile(`notes/.masscode/assets/${healthyName}`, 'healthy')
+    writeFile(`notes/assets/${unknownName}`, 'unreferenced')
+    writeFile(
+      'notes/Assets.md',
+      [legacyName, equalName, conflictName, missingName, healthyName]
+        .map(name => `![](masscode://notes-asset/${name})`)
+        .join('\n'),
+    )
+
+    const trackedPaths = [
+      `notes/assets/${legacyName}`,
+      `notes/assets/${equalName}`,
+      `notes/.masscode/assets/${equalName}`,
+      `notes/assets/${conflictName}`,
+      `notes/.masscode/assets/${conflictName}`,
+      `notes/.masscode/assets/${healthyName}`,
+      `notes/assets/${unknownName}`,
+    ]
+    const before = trackedPaths.map(relativePath =>
+      fs.readFileSync(path.join(tempVaultPath, relativePath)),
+    )
+
+    const result = previewVaultDoctor({ spaces: ['notes'] })
+    const assetWarnings = result.warnings.filter(warning =>
+      warning.code.startsWith('NOTES_'),
+    )
+
+    expect(
+      assetWarnings.map(warning => [
+        warning.code,
+        warning.details?.assetName,
+        warning.path,
+      ]),
+    ).toEqual([
+      ['NOTES_LEGACY_ASSET', legacyName, 'Assets.md'],
+      ['NOTES_LEGACY_ASSET', equalName, 'Assets.md'],
+      ['NOTES_ASSET_DESTINATION_CONFLICT', conflictName, 'Assets.md'],
+      ['NOTES_ASSET_MISSING', missingName, 'Assets.md'],
+    ])
+    expect(
+      assetWarnings.every(
+        warning =>
+          Object.keys(warning.details ?? {})
+            .sort()
+            .join(',') === 'assetName,destination,reason,source',
+      ),
+    ).toBe(true)
+    trackedPaths.forEach((relativePath, index) => {
+      expect(fs.readFileSync(path.join(tempVaultPath, relativePath))).toEqual(
+        before[index],
+      )
+    })
+  })
+
+  it('reports placeholders as pending and one missing warning per note', () => {
+    const pendingName = 'abcdefghijklmnop.png'
+    const missingName = 'ponmlkjihgfedcba.jpg'
+    const unreadableName = 'qrstuvwxyzabcdef.png'
+    const pendingPath = writeSparseFile(`notes/assets/${pendingName}`)
+    const unreadableNotePath = path.join(tempVaultPath, 'notes/Unreadable.md')
+    writeFile(
+      'notes/One.md',
+      `![](masscode://notes-asset/${pendingName})\n![](masscode://notes-asset/${missingName})`,
+    )
+    writeFile('notes/Two.md', `![](masscode://notes-asset/${missingName})`)
+    writeFile(
+      'notes/Unreadable.md',
+      `![](masscode://notes-asset/${unreadableName})`,
+    )
+    fs.chmodSync(unreadableNotePath, 0o000)
+    setDatalessProbeForTests(absolutePath => absolutePath === pendingPath)
+
+    const result = previewVaultDoctor({ spaces: ['notes'] })
+
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'NOTES_ASSET_MIGRATION_PENDING',
+          details: expect.objectContaining({
+            assetName: pendingName,
+            reason: 'source-placeholder',
+          }),
+          path: 'One.md',
+        }),
+      ]),
+    )
+    expect(
+      result.warnings
+        .filter(
+          warning =>
+            warning.code === 'NOTES_ASSET_MISSING'
+            && warning.details?.assetName === missingName,
+        )
+        .map(warning => warning.path)
+        .sort(),
+    ).toEqual(['One.md', 'Two.md'])
+    expect(
+      result.warnings.some(
+        warning => warning.details?.assetName === unreadableName,
+      ),
+    ).toBe(false)
+  })
+
+  it('treats non-regular asset paths as pending without reading them', () => {
+    const sourceDirectoryName = 'abcdefghijklmnop.png'
+    const destinationDirectoryName = 'ponmlkjihgfedcba.jpg'
+    fs.ensureDirSync(
+      path.join(tempVaultPath, 'notes/assets', sourceDirectoryName),
+    )
+    fs.ensureDirSync(
+      path.join(
+        tempVaultPath,
+        'notes/.masscode/assets',
+        destinationDirectoryName,
+      ),
+    )
+    writeFile(
+      'notes/Directories.md',
+      [sourceDirectoryName, destinationDirectoryName]
+        .map(name => `![](masscode://notes-asset/${name})`)
+        .join('\n'),
+    )
+
+    const result = previewVaultDoctor({ spaces: ['notes'] })
+
+    expect(
+      result.warnings
+        .filter(warning => warning.path === 'Directories.md')
+        .map(warning => warning.details?.reason),
+    ).toEqual(['source-not-regular', 'destination-not-regular'])
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'treats source and destination symlinks as pending without touching targets',
+    () => {
+      const sourceSymlinkName = 'qrstuvwxyzabcdef.png'
+      const destinationSymlinkName = 'fedcbazyxwvutsrq.jpg'
+      const externalPath = path.join(tempVaultPath, 'external.bin')
+      const externalBytes = Buffer.from([0x10, 0x20, 0x30, 0x40])
+      fs.writeFileSync(externalPath, externalBytes)
+      fs.ensureDirSync(path.join(tempVaultPath, 'notes/assets'))
+      fs.ensureDirSync(path.join(tempVaultPath, 'notes/.masscode/assets'))
+      fs.symlinkSync(
+        externalPath,
+        path.join(tempVaultPath, 'notes/assets', sourceSymlinkName),
+      )
+      fs.symlinkSync(
+        externalPath,
+        path.join(
+          tempVaultPath,
+          'notes/.masscode/assets',
+          destinationSymlinkName,
+        ),
+      )
+      writeFile(
+        'notes/Symlinks.md',
+        [sourceSymlinkName, destinationSymlinkName]
+          .map(name => `![](masscode://notes-asset/${name})`)
+          .join('\n'),
+      )
+
+      const result = previewVaultDoctor({ spaces: ['notes'] })
+
+      expect(
+        result.warnings
+          .filter(warning => warning.path === 'Symlinks.md')
+          .map(warning => warning.details?.reason),
+      ).toEqual(['source-symlink', 'destination-symlink'])
+      expect(fs.readFileSync(externalPath)).toEqual(externalBytes)
+    },
+  )
+
+  it('does not migrate referenced legacy assets while applying Notes repairs', async () => {
+    const assetName = 'abcdefghijklmnop.png'
+    const sourcePath = path.join(tempVaultPath, 'notes/assets', assetName)
+    const destinationPath = path.join(
+      tempVaultPath,
+      'notes/.masscode/assets',
+      assetName,
+    )
+    const assetBytes = Buffer.from([0x01, 0x02, 0xFE, 0xFF])
+    fs.ensureDirSync(path.dirname(sourcePath))
+    fs.writeFileSync(sourcePath, assetBytes)
+    writeFile('notes/Repair.md', `![](masscode://notes-asset/${assetName})`)
+
+    applyVaultDoctor({ spaces: ['notes'] })
+    await waitForNotesAssetsMigrationForTests()
+    await Promise.resolve()
+
+    expect(fs.readFileSync(sourcePath)).toEqual(assetBytes)
+    expect(fs.pathExistsSync(destinationPath)).toBe(false)
   })
 
   it('reports duplicate code snippet ids as conflicts that need a decision', () => {

--- a/src/main/storage/providers/markdown/__tests__/notesAssetEvents.test.ts
+++ b/src/main/storage/providers/markdown/__tests__/notesAssetEvents.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const send = vi.fn()
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => [{ webContents: { send } }],
+  },
+}))
+
+describe('notes asset ready events', () => {
+  it('broadcasts a targeted completion immediately', async () => {
+    const { broadcastNotesAssetReady } = await import('../notesAssetEvents')
+    broadcastNotesAssetReady('abcdefghijklmnop.png')
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith(
+      'system:notes-asset-ready',
+      'abcdefghijklmnop.png',
+    )
+  })
+})

--- a/src/main/storage/providers/markdown/__tests__/watcher.test.ts
+++ b/src/main/storage/providers/markdown/__tests__/watcher.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getManagedNotesAssetName,
   getWatchPathSpaceId,
   isCodeWatchPath,
   isHttpWatchPath,
+  isManagedNotesAssetsPath,
   isMathWatchPath,
   isNotesWatchPath,
   normalizeRelativeWatchPath,
@@ -54,6 +56,25 @@ describe('watcher routing', () => {
     expect(shouldIgnoreWatchPath(vaultRoot, '/vault/notes/.obsidian')).toBe(
       false,
     )
+  })
+
+  it('routes managed Notes assets without hiding legacy assets', () => {
+    expect(
+      getManagedNotesAssetName('notes/.masscode/assets/abcdefghijklmnop.png'),
+    ).toBe('abcdefghijklmnop.png')
+    expect(
+      getManagedNotesAssetName('notes/assets/abcdefghijklmnop.png'),
+    ).toBeNull()
+    expect(isManagedNotesAssetsPath('notes/.masscode/assets')).toBe(true)
+    expect(
+      isManagedNotesAssetsPath('notes/.masscode/assets/nested/file.png'),
+    ).toBe(true)
+    expect(
+      shouldIgnoreWatchPath(
+        vaultRoot,
+        '/vault/notes/assets/abcdefghijklmnop.png',
+      ),
+    ).toBe(false)
   })
 
   it('ignores hidden non-space paths', () => {

--- a/src/main/storage/providers/markdown/__tests__/watcherLifecycle.test.ts
+++ b/src/main/storage/providers/markdown/__tests__/watcherLifecycle.test.ts
@@ -43,6 +43,10 @@ async function setup() {
   const ensureStateFile = vi.fn()
   const syncRuntimeWithDisk = vi.fn()
   const syncNotesRuntimeWithDisk = vi.fn()
+  const scheduleNotesAssetsMigration = vi.fn()
+  const peekNotesRuntimeCache = vi.fn(
+    (): { paths: typeof notesPaths } | null => null,
+  )
   const syncHttpRuntimeWithDisk = vi.fn()
   const resetCloudDownloads = vi.fn()
   const getPendingCloudPaths = vi.fn(() => ['/vault/.masscode/state.json'])
@@ -106,10 +110,11 @@ async function setup() {
     ),
     getNotesPaths: vi.fn(() => notesPaths),
     parseNotesAssetName: vi.fn((fileName: string) => ({ fileName })),
-    peekNotesRuntimeCache: vi.fn(() => null),
+    peekNotesRuntimeCache,
     refreshPendingNoteFiles: vi.fn(() => ({ changed: false, remaining: 0 })),
     resetNotesPathsCache: vi.fn(),
     resetNotesRuntimeCache: vi.fn(),
+    scheduleNotesAssetsMigration,
     syncNoteFileWithDisk: vi.fn(),
     syncNotesRuntimeWithDisk,
   }))
@@ -163,9 +168,12 @@ async function setup() {
     getPendingCloudPaths,
     importEsm,
     log,
+    notesPaths,
     paths,
+    peekNotesRuntimeCache,
     prepareMarkdownWatcher,
     resetCloudDownloads,
+    scheduleNotesAssetsMigration,
     send,
     startMarkdownWatcher,
     stopMarkdownWatcher,
@@ -235,6 +243,9 @@ describe('markdown watcher cloud bootstrap', () => {
     context.startMarkdownWatcher()
     await flushImmediate()
     expect(context.syncNotesRuntimeWithDisk).toHaveBeenCalledTimes(1)
+    context.peekNotesRuntimeCache.mockReturnValue({
+      paths: context.notesPaths,
+    })
 
     context.watcherHandlers.get('change')?.(
       '/vault/notes/.masscode/assets/abcdefghijklmnop.png',
@@ -252,6 +263,7 @@ describe('markdown watcher cloud bootstrap', () => {
       'ponmlkjihgfedcba.png',
     )
     expect(context.syncNotesRuntimeWithDisk).toHaveBeenCalledTimes(1)
+    expect(context.scheduleNotesAssetsMigration).toHaveBeenCalledTimes(1)
   })
 
   it('retries startup after a legacy cloud state file is hydrated', async () => {

--- a/src/main/storage/providers/markdown/__tests__/watcherLifecycle.test.ts
+++ b/src/main/storage/providers/markdown/__tests__/watcherLifecycle.test.ts
@@ -22,7 +22,9 @@ async function setup() {
     vaultPath: '/vault/code',
   }
   const notesPaths = {
+    assetsPath: '/vault/notes/.masscode/assets',
     inboxDirPath: '/vault/notes/.masscode/inbox',
+    legacyAssetsPath: '/vault/notes/assets',
     metaDirPath: '/vault/notes/.masscode',
     notesRoot: '/vault/notes',
     statePath: '/vault/notes/.masscode/state.json',
@@ -35,6 +37,7 @@ async function setup() {
   const cloudConfigurations: CloudDownloadConfiguration[] = []
   const send = vi.fn()
   const log = vi.fn()
+  const broadcastNotesAssetReady = vi.fn()
   const getPaths = vi.fn(() => paths)
   const getVaultPath = vi.fn(() => vaultRootPath)
   const ensureStateFile = vi.fn()
@@ -48,11 +51,14 @@ async function setup() {
       cloudConfigurations.push(configuration)
     },
   )
+  const watcherHandlers = new Map<string, (changedPath: string) => void>()
   const watcher = {
     close: vi.fn(),
-    on: vi.fn(),
+    on: vi.fn((event: string, handler: (changedPath: string) => void) => {
+      watcherHandlers.set(event, handler)
+      return watcher
+    }),
   }
-  watcher.on.mockReturnValue(watcher)
   const watch = vi.fn(() => watcher)
   const importEsm = vi.fn(async () => ({ watch }))
 
@@ -65,6 +71,10 @@ async function setup() {
   vi.doMock('../../../../utils', () => ({
     importEsm,
     log,
+  }))
+
+  vi.doMock('../../../../dockBadge', () => ({
+    scheduleDockBadgeRefresh: vi.fn(),
   }))
 
   vi.doMock('../cloudDownloads', () => ({
@@ -85,13 +95,27 @@ async function setup() {
   }))
 
   vi.doMock('../notes/runtime', () => ({
+    getNotesAssetNameFromAbsolutePath: vi.fn(
+      (_paths: typeof notesPaths, absolutePath: string) => {
+        const parentPath = absolutePath.slice(0, absolutePath.lastIndexOf('/'))
+        return parentPath === notesPaths.assetsPath
+          || parentPath === notesPaths.legacyAssetsPath
+          ? absolutePath.slice(absolutePath.lastIndexOf('/') + 1)
+          : null
+      },
+    ),
     getNotesPaths: vi.fn(() => notesPaths),
+    parseNotesAssetName: vi.fn((fileName: string) => ({ fileName })),
     peekNotesRuntimeCache: vi.fn(() => null),
     refreshPendingNoteFiles: vi.fn(() => ({ changed: false, remaining: 0 })),
     resetNotesPathsCache: vi.fn(),
     resetNotesRuntimeCache: vi.fn(),
     syncNoteFileWithDisk: vi.fn(),
     syncNotesRuntimeWithDisk,
+  }))
+
+  vi.doMock('../notesAssetEvents', () => ({
+    broadcastNotesAssetReady,
   }))
 
   vi.doMock('../runtime', () => ({
@@ -127,12 +151,12 @@ async function setup() {
       && error.message.startsWith('CLOUD_FILE_NOT_DOWNLOADED'),
   }))
 
-  const { startMarkdownWatcher, stopMarkdownWatcher } = await import(
-    '../watcher'
-  )
+  const { prepareMarkdownWatcher, startMarkdownWatcher, stopMarkdownWatcher }
+    = await import('../watcher')
 
   return {
     cloudConfigurations,
+    broadcastNotesAssetReady,
     configureCloudDownloads,
     ensureStateFile,
     getPaths,
@@ -140,6 +164,8 @@ async function setup() {
     importEsm,
     log,
     paths,
+    prepareMarkdownWatcher,
+    resetCloudDownloads,
     send,
     startMarkdownWatcher,
     stopMarkdownWatcher,
@@ -147,6 +173,7 @@ async function setup() {
     syncNotesRuntimeWithDisk,
     syncRuntimeWithDisk,
     watch,
+    watcherHandlers,
   }
 }
 
@@ -155,6 +182,78 @@ beforeEach(() => {
 })
 
 describe('markdown watcher cloud bootstrap', () => {
+  it('broadcasts an asset hydrated before the watcher starts', async () => {
+    const context = await setup()
+
+    context.prepareMarkdownWatcher()
+    context.cloudConfigurations[0].onDownloaded(
+      '/vault/notes/.masscode/assets/abcdefghijklmnop.png',
+    )
+
+    expect(context.broadcastNotesAssetReady).toHaveBeenCalledWith(
+      'abcdefghijklmnop.png',
+    )
+  })
+
+  it('preserves the prepared cloud queue on the initial start', async () => {
+    const context = await setup()
+
+    context.prepareMarkdownWatcher()
+    context.startMarkdownWatcher()
+    await flushImmediate()
+
+    expect(context.resetCloudDownloads).not.toHaveBeenCalled()
+    expect(context.configureCloudDownloads).toHaveBeenCalledTimes(2)
+  })
+
+  it('resets cloud downloads on a later stop and restart', async () => {
+    const context = await setup()
+
+    context.prepareMarkdownWatcher()
+    context.startMarkdownWatcher()
+    await flushImmediate()
+    context.stopMarkdownWatcher()
+    context.startMarkdownWatcher()
+
+    expect(context.resetCloudDownloads).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancels a pending initial start when start is called again', async () => {
+    const context = await setup()
+
+    context.prepareMarkdownWatcher()
+    context.startMarkdownWatcher()
+    context.startMarkdownWatcher()
+    await flushImmediate()
+
+    expect(context.resetCloudDownloads).toHaveBeenCalledTimes(1)
+    expect(context.watch).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes managed watch and asset hydration events without Notes sync', async () => {
+    const context = await setup()
+    context.startMarkdownWatcher()
+    await flushImmediate()
+    expect(context.syncNotesRuntimeWithDisk).toHaveBeenCalledTimes(1)
+
+    context.watcherHandlers.get('change')?.(
+      '/vault/notes/.masscode/assets/abcdefghijklmnop.png',
+    )
+    context.cloudConfigurations[0].onDownloaded(
+      '/vault/notes/assets/ponmlkjihgfedcba.png',
+    )
+
+    expect(context.broadcastNotesAssetReady).toHaveBeenNthCalledWith(
+      1,
+      'abcdefghijklmnop.png',
+    )
+    expect(context.broadcastNotesAssetReady).toHaveBeenNthCalledWith(
+      2,
+      'ponmlkjihgfedcba.png',
+    )
+    expect(context.syncNotesRuntimeWithDisk).toHaveBeenCalledTimes(1)
+  })
+
   it('retries startup after a legacy cloud state file is hydrated', async () => {
     const context = await setup()
     context.getPaths

--- a/src/main/storage/providers/markdown/doctor.ts
+++ b/src/main/storage/providers/markdown/doctor.ts
@@ -5,7 +5,7 @@ import type {
   VaultDoctorWarning,
 } from '../../../api/dto/vault-doctor'
 import type { MathNotebookStore, MathSheet } from '../../../store/types'
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import path from 'node:path'
 import fs from 'fs-extra'
 import yaml from 'js-yaml'
@@ -17,6 +17,7 @@ import {
   syncHttpRuntimeWithDisk,
 } from './http/runtime'
 import {
+  extractNotesAssetNames,
   getNotesPaths,
   isNotesVaultDiskReady,
   loadNotesState,
@@ -66,6 +67,12 @@ interface EntityScanRecord {
   id: number
   kind: 'note' | 'snippet'
   space: Extract<VaultDoctorSpace, 'code' | 'http' | 'notes'>
+}
+
+interface InspectedNotesAssetPath {
+  exists: boolean
+  invalidReason: string | null
+  isCloudPlaceholder: boolean
 }
 
 const DEFAULT_SPACES: VaultDoctorSpace[] = ['code', 'notes', 'http', 'math']
@@ -130,6 +137,168 @@ function addItem(context: ScanContext, item: VaultDoctorItem): void {
 
 function addWarning(context: ScanContext, warning: VaultDoctorWarning): void {
   context.warnings.push(warning)
+}
+
+function hashLocalFile(absolutePath: string): string {
+  return createHash('sha256')
+    .update(fs.readFileSync(absolutePath))
+    .digest('hex')
+}
+
+function inspectNotesAssetPath(
+  absolutePath: string,
+  location: 'destination' | 'source',
+): InspectedNotesAssetPath {
+  try {
+    const stats = fs.lstatSync(absolutePath)
+    if (stats.isSymbolicLink()) {
+      return {
+        exists: true,
+        invalidReason: `${location}-symlink`,
+        isCloudPlaceholder: false,
+      }
+    }
+    if (!stats.isFile()) {
+      return {
+        exists: true,
+        invalidReason: `${location}-not-regular`,
+        isCloudPlaceholder: false,
+      }
+    }
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {
+        exists: false,
+        invalidReason: null,
+        isCloudPlaceholder: false,
+      }
+    }
+    return {
+      exists: true,
+      invalidReason: `${location}-inspection-unavailable`,
+      isCloudPlaceholder: false,
+    }
+  }
+
+  const availability = getFileAvailability(absolutePath)
+  if (!availability.exists) {
+    return {
+      exists: true,
+      invalidReason: `${location}-inspection-unavailable`,
+      isCloudPlaceholder: false,
+    }
+  }
+
+  return {
+    exists: true,
+    invalidReason: null,
+    isCloudPlaceholder: availability.isCloudPlaceholder,
+  }
+}
+
+function inspectNotesAssets(input: {
+  context: ScanContext
+  notePath: string
+  notesRoot: string
+  source: string
+}): void {
+  const paths = getNotesPaths(getVaultPath())
+
+  for (const assetName of extractNotesAssetNames(input.source)) {
+    const sourcePath = path.join(paths.legacyAssetsPath, assetName)
+    const destinationPath = path.join(paths.assetsPath, assetName)
+    const sourceAvailability = inspectNotesAssetPath(sourcePath, 'source')
+    const destinationAvailability = inspectNotesAssetPath(
+      destinationPath,
+      'destination',
+    )
+    const details = {
+      assetName,
+      destination: toPosixPath(path.relative(input.notesRoot, destinationPath)),
+      source: toPosixPath(path.relative(input.notesRoot, sourcePath)),
+    }
+
+    const invalidReason
+      = sourceAvailability.invalidReason ?? destinationAvailability.invalidReason
+    if (invalidReason) {
+      addWarning(input.context, {
+        code: 'NOTES_ASSET_MIGRATION_PENDING',
+        details: { ...details, reason: invalidReason },
+        path: input.notePath,
+        space: 'notes',
+      })
+      continue
+    }
+
+    if (
+      sourceAvailability.isCloudPlaceholder
+      || destinationAvailability.isCloudPlaceholder
+    ) {
+      addWarning(input.context, {
+        code: 'NOTES_ASSET_MIGRATION_PENDING',
+        details: {
+          ...details,
+          reason:
+            sourceAvailability.isCloudPlaceholder
+            && destinationAvailability.isCloudPlaceholder
+              ? 'source-and-destination-placeholder'
+              : sourceAvailability.isCloudPlaceholder
+                ? 'source-placeholder'
+                : 'destination-placeholder',
+        },
+        path: input.notePath,
+        space: 'notes',
+      })
+      continue
+    }
+
+    if (sourceAvailability.exists && destinationAvailability.exists) {
+      try {
+        const isEqual
+          = hashLocalFile(sourcePath) === hashLocalFile(destinationPath)
+        addWarning(input.context, {
+          code: isEqual
+            ? 'NOTES_LEGACY_ASSET'
+            : 'NOTES_ASSET_DESTINATION_CONFLICT',
+          details: {
+            ...details,
+            reason: isEqual ? 'legacy-copy-remains' : 'content-mismatch',
+          },
+          path: input.notePath,
+          space: 'notes',
+        })
+      }
+      catch {
+        addWarning(input.context, {
+          code: 'NOTES_ASSET_MIGRATION_PENDING',
+          details: { ...details, reason: 'inspection-unavailable' },
+          path: input.notePath,
+          space: 'notes',
+        })
+      }
+      continue
+    }
+
+    if (sourceAvailability.exists) {
+      addWarning(input.context, {
+        code: 'NOTES_LEGACY_ASSET',
+        details: { ...details, reason: 'destination-missing' },
+        path: input.notePath,
+        space: 'notes',
+      })
+      continue
+    }
+
+    if (!destinationAvailability.exists) {
+      addWarning(input.context, {
+        code: 'NOTES_ASSET_MISSING',
+        details: { ...details, reason: 'source-and-destination-missing' },
+        path: input.notePath,
+        space: 'notes',
+      })
+    }
+  }
 }
 
 function createFileItem(input: {
@@ -279,6 +448,15 @@ function inspectMarkdownEntity(input: {
   catch {
     enqueueCloudDownload(absolutePath)
     return null
+  }
+
+  if (input.space === 'notes') {
+    inspectNotesAssets({
+      context: input.context,
+      notePath: input.filePath,
+      notesRoot: input.rootPath,
+      source,
+    })
   }
 
   const fileName = path.basename(input.filePath)
@@ -1096,7 +1274,9 @@ export function applyVaultDoctor(
     syncRuntimeWithDisk(getPaths(getVaultPath()))
   }
   if (spaces.includes('notes') && !conflictedSpaces.has('notes')) {
-    syncNotesRuntimeWithDisk(getNotesPaths(getVaultPath()))
+    syncNotesRuntimeWithDisk(getNotesPaths(getVaultPath()), {
+      scheduleAssetsMigration: false,
+    })
   }
   if (spaces.includes('http')) {
     if (!conflictedSpaces.has('http')) {

--- a/src/main/storage/providers/markdown/index.ts
+++ b/src/main/storage/providers/markdown/index.ts
@@ -5,4 +5,8 @@ export {
   resetRuntimeCache,
 } from './runtime'
 export { createMarkdownStorageProvider } from './storages'
-export { startMarkdownWatcher, stopMarkdownWatcher } from './watcher'
+export {
+  prepareMarkdownWatcher,
+  startMarkdownWatcher,
+  stopMarkdownWatcher,
+} from './watcher'

--- a/src/main/storage/providers/markdown/notes/runtime/__tests__/assets.test.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/__tests__/assets.test.ts
@@ -1,0 +1,224 @@
+import type { NotesPaths } from '../types'
+import { Buffer } from 'node:buffer'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'fs-extra'
+import { afterEach, describe, expect, it } from 'vitest'
+import { setDatalessProbeForTests } from '../../../runtime/shared/cloudFiles'
+import {
+  parseNotesAssetName,
+  parseNotesAssetWritePayload,
+  resolveNotesAsset,
+  writeNotesAsset,
+} from '../assets'
+
+const tempDirs: string[] = []
+
+function createNotesPaths(): NotesPaths {
+  const notesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'notes-assets-'))
+  tempDirs.push(notesRoot)
+  const metaDirPath = path.join(notesRoot, '.masscode')
+
+  return {
+    assetsPath: path.join(metaDirPath, 'assets'),
+    inboxDirPath: path.join(metaDirPath, 'inbox'),
+    legacyAssetsPath: path.join(notesRoot, 'assets'),
+    metaDirPath,
+    notesRoot,
+    statePath: path.join(metaDirPath, 'state.json'),
+    trashDirPath: path.join(metaDirPath, 'trash'),
+  }
+}
+
+function pngBytes(): ArrayBuffer {
+  return Uint8Array.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00])
+    .buffer
+}
+
+function jpegBytes(): ArrayBuffer {
+  return Uint8Array.from([0xFF, 0xD8, 0xFF, 0xD9]).buffer
+}
+
+afterEach(() => {
+  setDatalessProbeForTests(null)
+  for (const dirPath of tempDirs.splice(0)) {
+    fs.removeSync(dirPath)
+  }
+})
+
+describe('notes asset validation', () => {
+  it('accepts current and historical generated names case-insensitively', () => {
+    expect(parseNotesAssetName('abcdefghijklmnop.PNG')).toMatchObject({
+      extension: '.png',
+      mimeType: 'image/png',
+    })
+    expect(parseNotesAssetName('abcdefghijklmnopqrstu.JpEg')).toMatchObject({
+      extension: '.jpeg',
+      mimeType: 'image/jpeg',
+    })
+  })
+
+  it.each([
+    '../abcdefghijklmnop.png',
+    '..%2Fabcdefghijklmnop.png',
+    '%2e%2e%5cabcdefghijklmnop.png',
+    'short.png',
+    'abcdefghijklmnop.exe',
+  ])('rejects unsafe or unsupported name %s', (fileName) => {
+    expect(parseNotesAssetName(fileName)).toBeNull()
+  })
+
+  it('accepts only an object with string ext and ArrayBuffer bytes', () => {
+    expect(parseNotesAssetWritePayload(null)).toBeNull()
+    expect(parseNotesAssetWritePayload({ buffer: [0], ext: 1 })).toBeNull()
+    expect(
+      parseNotesAssetWritePayload({ buffer: [0, 1], ext: '.png' }),
+    ).toBeNull()
+    expect(
+      parseNotesAssetWritePayload({ buffer: pngBytes(), ext: '.png' }),
+    ).toMatchObject({ ext: '.png' })
+  })
+})
+
+describe('writeNotesAsset', () => {
+  it('writes atomically to the managed root and returns the stable URL', async () => {
+    const paths = createNotesPaths()
+    const url = await writeNotesAsset(
+      paths,
+      pngBytes(),
+      '.PNG',
+      () => 'abcdefghijklmnop',
+    )
+
+    expect(url).toBe('masscode://notes-asset/abcdefghijklmnop.png')
+    expect(
+      fs.readFileSync(path.join(paths.assetsPath, 'abcdefghijklmnop.png')),
+    ).toEqual(Buffer.from(pngBytes()))
+    expect(fs.pathExistsSync(paths.legacyAssetsPath)).toBe(false)
+    expect(fs.readdirSync(paths.assetsPath)).toEqual(['abcdefghijklmnop.png'])
+  })
+
+  it('accepts a JPEG signature for JPG uploads', async () => {
+    const paths = createNotesPaths()
+
+    const url = await writeNotesAsset(
+      paths,
+      jpegBytes(),
+      '.JPG',
+      () => 'abcdefghijklmnop',
+    )
+
+    expect(url).toBe('masscode://notes-asset/abcdefghijklmnop.jpg')
+  })
+
+  it('rejects SVG, mismatched bytes, and an existing destination', async () => {
+    const paths = createNotesPaths()
+    await expect(
+      writeNotesAsset(paths, new TextEncoder().encode('<svg/>').buffer, '.svg'),
+    ).rejects.toThrow('Unsupported')
+    await expect(
+      writeNotesAsset(
+        paths,
+        new TextEncoder().encode('not png').buffer,
+        '.png',
+      ),
+    ).rejects.toThrow('does not match')
+
+    fs.ensureDirSync(paths.assetsPath)
+    const destination = path.join(paths.assetsPath, 'abcdefghijklmnop.png')
+    fs.writeFileSync(destination, 'existing')
+    await expect(
+      writeNotesAsset(paths, pngBytes(), '.png', () => 'abcdefghijklmnop'),
+    ).rejects.toThrow('already exists')
+    expect(fs.readFileSync(destination, 'utf8')).toBe('existing')
+    expect(fs.readdirSync(paths.assetsPath)).toEqual(['abcdefghijklmnop.png'])
+  })
+})
+
+describe('resolveNotesAsset', () => {
+  it('prefers the managed root and falls back to legacy', async () => {
+    const paths = createNotesPaths()
+    const fileName = 'abcdefghijklmnop.png'
+    fs.ensureDirSync(paths.assetsPath)
+    fs.ensureDirSync(paths.legacyAssetsPath)
+    fs.writeFileSync(path.join(paths.assetsPath, fileName), 'new')
+    fs.writeFileSync(path.join(paths.legacyAssetsPath, fileName), 'legacy')
+
+    const preferred = await resolveNotesAsset(fileName, paths)
+    expect(await preferred.text()).toBe('new')
+    fs.removeSync(path.join(paths.assetsPath, fileName))
+
+    const fallback = await resolveNotesAsset(fileName, paths)
+    expect(await fallback.text()).toBe('legacy')
+    expect(fallback.headers.get('Content-Type')).toBe('image/png')
+  })
+
+  it('does not mask a managed placeholder with a legacy file', async () => {
+    const paths = createNotesPaths()
+    const fileName = 'abcdefghijklmnop.png'
+    const managedPath = path.join(paths.assetsPath, fileName)
+    fs.ensureDirSync(paths.assetsPath)
+    fs.ensureDirSync(paths.legacyAssetsPath)
+    const placeholderFd = fs.openSync(managedPath, 'w')
+    fs.ftruncateSync(placeholderFd, 4096)
+    fs.closeSync(placeholderFd)
+    fs.writeFileSync(path.join(paths.legacyAssetsPath, fileName), 'legacy')
+    setDatalessProbeForTests(absolutePath => absolutePath === managedPath)
+    const prioritized: string[] = []
+
+    const response = await resolveNotesAsset(fileName, paths, absolutePath =>
+      prioritized.push(absolutePath))
+
+    expect(response.status).toBe(503)
+    expect(prioritized).toEqual([managedPath])
+    expect(await response.text()).not.toBe('legacy')
+  })
+
+  it('returns a safe 404 for traversal', async () => {
+    const response = await resolveNotesAsset(
+      '..%2Fabcdefghijklmnop.png',
+      createNotesPaths(),
+    )
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+  })
+
+  it('serves legacy SVG with active content blocked', async () => {
+    const paths = createNotesPaths()
+    const fileName = 'abcdefghijklmnop.svg'
+    fs.ensureDirSync(paths.legacyAssetsPath)
+    fs.writeFileSync(path.join(paths.legacyAssetsPath, fileName), '<svg/>')
+
+    const response = await resolveNotesAsset(fileName, paths)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('image/svg+xml')
+    expect(response.headers.get('Content-Security-Policy')).toContain(
+      'sandbox',
+    )
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+  })
+
+  it.runIf(process.platform !== 'win32')(
+    'does not follow a direct asset file symlink',
+    async () => {
+      const fileName = 'abcdefghijklmnop.png'
+      const outsideRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'notes-outside-'),
+      )
+      tempDirs.push(outsideRoot)
+      fs.writeFileSync(path.join(outsideRoot, fileName), 'outside')
+
+      const fileSymlinkPaths = createNotesPaths()
+      fs.ensureDirSync(fileSymlinkPaths.assetsPath)
+      fs.symlinkSync(
+        path.join(outsideRoot, fileName),
+        path.join(fileSymlinkPaths.assetsPath, fileName),
+      )
+      expect((await resolveNotesAsset(fileName, fileSymlinkPaths)).status).toBe(
+        404,
+      )
+    },
+  )
+})

--- a/src/main/storage/providers/markdown/notes/runtime/__tests__/assetsMigration.test.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/__tests__/assetsMigration.test.ts
@@ -1,0 +1,393 @@
+import type { MarkdownNote, NotesPaths, NotesRuntimeCache } from '../types'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'fs-extra'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setDatalessProbeForTests } from '../../../runtime/shared/cloudFiles'
+import {
+  cancelNotesAssetsMigration,
+  discoverNotesAssetReferences,
+  runNotesAssetsMigration,
+  runNotesAssetsMigrationForTests,
+  scheduleNotesAssetsMigration,
+  waitForNotesAssetsMigrationForTests,
+} from '../assetsMigration'
+
+const { enqueueCloudDownload, prioritizeCloudDownload } = vi.hoisted(() => ({
+  enqueueCloudDownload: vi.fn(),
+  prioritizeCloudDownload: vi.fn(),
+}))
+
+vi.mock('../../../cloudDownloads', () => ({
+  enqueueCloudDownload,
+  prioritizeCloudDownload,
+}))
+
+vi.mock('../../../../../../utils', () => ({
+  log: vi.fn(),
+}))
+
+const tempDirs: string[] = []
+
+function createPaths(): NotesPaths {
+  const notesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'assets-migration-'))
+  tempDirs.push(notesRoot)
+  const metaDirPath = path.join(notesRoot, '.masscode')
+
+  return {
+    assetsPath: path.join(metaDirPath, 'assets'),
+    inboxDirPath: path.join(metaDirPath, 'inbox'),
+    legacyAssetsPath: path.join(notesRoot, 'assets'),
+    metaDirPath,
+    notesRoot,
+    statePath: path.join(metaDirPath, 'state.json'),
+    trashDirPath: path.join(metaDirPath, 'trash'),
+  }
+}
+
+function createNote(
+  id: number,
+  content: string | null,
+  pendingCloudDownload = false,
+): MarkdownNote {
+  return {
+    content,
+    createdAt: 1,
+    description: null,
+    filePath: `Note ${id}.md`,
+    folderId: null,
+    id,
+    isDeleted: 0,
+    isFavorites: 0,
+    name: `Note ${id}`,
+    ...(pendingCloudDownload ? { pendingCloudDownload: true } : {}),
+    properties: {},
+    tags: [],
+    updatedAt: 1,
+  }
+}
+
+function createCache(
+  paths: NotesPaths,
+  notes: MarkdownNote[],
+): NotesRuntimeCache {
+  return {
+    folderById: new Map(),
+    noteById: new Map(notes.map(note => [note.id, note])),
+    notes,
+    paths,
+    searchIndex: {} as NotesRuntimeCache['searchIndex'],
+    state: {
+      counters: { folderId: 0, noteId: notes.length, tagId: 0 },
+      folderUi: {},
+      folders: [],
+      notes: notes.map(note => ({ filePath: note.filePath, id: note.id })),
+      tags: [],
+      version: 1,
+    },
+  }
+}
+
+function assetUrl(fileName: string): string {
+  return `![asset](masscode://notes-asset/${fileName})`
+}
+
+function writeLegacyAsset(paths: NotesPaths, fileName: string, data: string) {
+  fs.ensureDirSync(paths.legacyAssetsPath)
+  fs.writeFileSync(path.join(paths.legacyAssetsPath, fileName), data)
+}
+
+function writeSparseFile(filePath: string): void {
+  fs.ensureDirSync(path.dirname(filePath))
+  const fd = fs.openSync(filePath, 'w')
+  fs.ftruncateSync(fd, 4096)
+  fs.closeSync(fd)
+}
+
+afterEach(() => {
+  cancelNotesAssetsMigration()
+  setDatalessProbeForTests(null)
+  vi.clearAllMocks()
+  for (const dirPath of tempDirs.splice(0)) {
+    fs.removeSync(dirPath)
+  }
+})
+
+describe('notes assets migration discovery', () => {
+  it('collects only valid references from available note content', () => {
+    const paths = createPaths()
+    const availableName = 'abcdefghijklmnop.png'
+    const pendingName = 'ponmlkjihgfedcba.jpg'
+    const cache = createCache(paths, [
+      createNote(1, `${assetUrl(availableName)} ${assetUrl('../bad.png')}`),
+      createNote(2, assetUrl(pendingName), true),
+    ])
+
+    const discovery = discoverNotesAssetReferences(cache)
+
+    expect(discovery.complete).toBe(false)
+    expect([...discovery.fileNames]).toEqual([availableName])
+    expect(enqueueCloudDownload).toHaveBeenCalledWith(
+      path.join(paths.notesRoot, 'Note 2.md'),
+    )
+  })
+})
+
+describe('runNotesAssetsMigration', () => {
+  it('migrates only referenced direct legacy assets', async () => {
+    const paths = createPaths()
+    const referenced = 'abcdefghijklmnop.png'
+    const unreferenced = 'ponmlkjihgfedcba.png'
+    writeLegacyAsset(paths, referenced, 'referenced bytes')
+    writeLegacyAsset(paths, unreferenced, 'unreferenced bytes')
+
+    const summary = await runNotesAssetsMigration(
+      createCache(paths, [createNote(1, assetUrl(referenced))]),
+    )
+
+    expect(summary.migrated).toBe(1)
+    expect(
+      fs.readFileSync(path.join(paths.assetsPath, referenced), 'utf8'),
+    ).toBe('referenced bytes')
+    expect(
+      fs.pathExistsSync(path.join(paths.legacyAssetsPath, referenced)),
+    ).toBe(false)
+    expect(
+      fs.pathExistsSync(path.join(paths.legacyAssetsPath, unreferenced)),
+    ).toBe(true)
+  })
+
+  it('removes a verified equal source and preserves a conflict', async () => {
+    const paths = createPaths()
+    const equalName = 'abcdefghijklmnop.png'
+    const conflictName = 'ponmlkjihgfedcba.jpg'
+    writeLegacyAsset(paths, equalName, 'same')
+    writeLegacyAsset(paths, conflictName, 'source')
+    fs.ensureDirSync(paths.assetsPath)
+    fs.writeFileSync(path.join(paths.assetsPath, equalName), 'same')
+    fs.writeFileSync(path.join(paths.assetsPath, conflictName), 'destination')
+
+    const summary = await runNotesAssetsMigration(
+      createCache(paths, [
+        createNote(1, `${assetUrl(equalName)} ${assetUrl(conflictName)}`),
+      ]),
+    )
+
+    expect(summary.removedEqual).toBe(1)
+    expect(summary.conflicts).toBe(1)
+    expect(
+      fs.pathExistsSync(path.join(paths.legacyAssetsPath, equalName)),
+    ).toBe(false)
+    expect(
+      fs.readFileSync(path.join(paths.legacyAssetsPath, conflictName), 'utf8'),
+    ).toBe('source')
+    expect(
+      fs.readFileSync(path.join(paths.assetsPath, conflictName), 'utf8'),
+    ).toBe('destination')
+  })
+
+  it('re-evaluates atomic EEXIST without overwriting a concurrent destination', async () => {
+    const paths = createPaths()
+    const fileName = 'abcdefghijklmnop.png'
+    writeLegacyAsset(paths, fileName, 'source')
+
+    const summary = await runNotesAssetsMigrationForTests(
+      createCache(paths, [createNote(1, assetUrl(fileName))]),
+      () => false,
+      {
+        beforePublish: ({ destinationPath }) => {
+          fs.writeFileSync(destinationPath, 'concurrent')
+        },
+      },
+    )
+
+    expect(summary.conflicts).toBe(1)
+    expect(fs.readFileSync(path.join(paths.assetsPath, fileName), 'utf8')).toBe(
+      'concurrent',
+    )
+    expect(
+      fs.readFileSync(path.join(paths.legacyAssetsPath, fileName), 'utf8'),
+    ).toBe('source')
+  })
+
+  it('does not remove a concurrent replacement after publish mismatch', async () => {
+    const paths = createPaths()
+    const fileName = 'abcdefghijklmnop.png'
+    writeLegacyAsset(paths, fileName, 'source')
+
+    const summary = await runNotesAssetsMigrationForTests(
+      createCache(paths, [createNote(1, assetUrl(fileName))]),
+      () => false,
+      {
+        afterPublish: ({ destinationPath }) => {
+          fs.unlinkSync(destinationPath)
+          fs.writeFileSync(destinationPath, 'replacement')
+        },
+      },
+    )
+
+    expect(summary.conflicts).toBe(1)
+    expect(fs.readFileSync(path.join(paths.assetsPath, fileName), 'utf8')).toBe(
+      'replacement',
+    )
+    expect(fs.pathExistsSync(path.join(paths.legacyAssetsPath, fileName))).toBe(
+      true,
+    )
+  })
+
+  it('removes an owned post-publish mismatch and always cleans its temp', async () => {
+    const paths = createPaths()
+    const fileName = 'abcdefghijklmnop.png'
+    writeLegacyAsset(paths, fileName, 'source')
+
+    const summary = await runNotesAssetsMigrationForTests(
+      createCache(paths, [createNote(1, assetUrl(fileName))]),
+      () => false,
+      {
+        afterPublish: ({ destinationPath }) => {
+          fs.writeFileSync(destinationPath, 'corrupt')
+        },
+      },
+    )
+
+    expect(summary.conflicts).toBe(1)
+    expect(fs.pathExistsSync(path.join(paths.assetsPath, fileName))).toBe(
+      false,
+    )
+    expect(fs.readdirSync(paths.assetsPath)).toEqual([])
+    expect(fs.pathExistsSync(path.join(paths.legacyAssetsPath, fileName))).toBe(
+      true,
+    )
+  })
+
+  it('checks cancellation immediately before final source deletion', async () => {
+    const paths = createPaths()
+    const fileName = 'abcdefghijklmnop.png'
+    writeLegacyAsset(paths, fileName, 'source')
+    let cancelled = false
+
+    const summary = await runNotesAssetsMigrationForTests(
+      createCache(paths, [createNote(1, assetUrl(fileName))]),
+      () => cancelled,
+      {
+        afterFinalDestinationHash: () => {
+          cancelled = true
+        },
+      },
+    )
+
+    expect(summary.deferred).toBe(1)
+    expect(fs.pathExistsSync(path.join(paths.legacyAssetsPath, fileName))).toBe(
+      true,
+    )
+    expect(fs.readFileSync(path.join(paths.assetsPath, fileName), 'utf8')).toBe(
+      'source',
+    )
+  })
+
+  it('preserves a source replaced during final destination verification', async () => {
+    const paths = createPaths()
+    const fileName = 'abcdefghijklmnop.png'
+    writeLegacyAsset(paths, fileName, 'source')
+
+    const summary = await runNotesAssetsMigrationForTests(
+      createCache(paths, [createNote(1, assetUrl(fileName))]),
+      () => false,
+      {
+        afterFinalDestinationHash: ({ sourcePath }) => {
+          fs.unlinkSync(sourcePath)
+          fs.writeFileSync(sourcePath, 'replacement source')
+        },
+      },
+    )
+
+    expect(summary.conflicts).toBe(1)
+    expect(
+      fs.readFileSync(path.join(paths.legacyAssetsPath, fileName), 'utf8'),
+    ).toBe('replacement source')
+    expect(fs.pathExistsSync(path.join(paths.assetsPath, fileName))).toBe(
+      false,
+    )
+  })
+
+  it('defers placeholders and prioritizes their hydration', async () => {
+    const paths = createPaths()
+    const sourceName = 'abcdefghijklmnop.png'
+    const destinationName = 'ponmlkjihgfedcba.jpg'
+    fs.ensureDirSync(paths.legacyAssetsPath)
+    writeLegacyAsset(paths, destinationName, 'source bytes')
+    fs.ensureDirSync(paths.assetsPath)
+    const sourcePath = path.join(paths.legacyAssetsPath, sourceName)
+    const destinationPath = path.join(paths.assetsPath, destinationName)
+    writeSparseFile(sourcePath)
+    writeSparseFile(destinationPath)
+    setDatalessProbeForTests(
+      absolutePath =>
+        absolutePath === sourcePath || absolutePath === destinationPath,
+    )
+
+    const summary = await runNotesAssetsMigration(
+      createCache(paths, [
+        createNote(1, `${assetUrl(sourceName)} ${assetUrl(destinationName)}`),
+      ]),
+    )
+
+    expect(summary.deferred).toBe(2)
+    expect(prioritizeCloudDownload).toHaveBeenCalledWith(sourcePath)
+    expect(prioritizeCloudDownload).toHaveBeenCalledWith(destinationPath)
+    expect(fs.pathExistsSync(sourcePath)).toBe(true)
+  })
+
+  it('isolates one item error and continues migrating the next asset', async () => {
+    const paths = createPaths()
+    const badName = 'abcdefghijklmnop.png'
+    const goodName = 'ponmlkjihgfedcba.jpg'
+    fs.ensureDirSync(path.join(paths.legacyAssetsPath, badName))
+    writeLegacyAsset(paths, goodName, 'good bytes')
+
+    const summary = await runNotesAssetsMigration(
+      createCache(paths, [
+        createNote(1, `${assetUrl(badName)} ${assetUrl(goodName)}`),
+      ]),
+    )
+
+    expect(summary.errors).toBe(1)
+    expect(summary.migrated).toBe(1)
+    expect(fs.pathExistsSync(path.join(paths.assetsPath, goodName))).toBe(true)
+  })
+
+  it('is idempotent and discovers a late reference on a future run', async () => {
+    const paths = createPaths()
+    const firstName = 'abcdefghijklmnop.png'
+    const lateName = 'ponmlkjihgfedcba.jpg'
+    writeLegacyAsset(paths, firstName, 'first')
+    writeLegacyAsset(paths, lateName, 'late')
+    const cache = createCache(paths, [createNote(1, assetUrl(firstName))])
+
+    expect((await runNotesAssetsMigration(cache)).migrated).toBe(1)
+    expect((await runNotesAssetsMigration(cache)).migrated).toBe(0)
+
+    cache.notes.push(createNote(2, assetUrl(lateName)))
+    expect((await runNotesAssetsMigration(cache)).migrated).toBe(1)
+    expect(fs.pathExistsSync(path.join(paths.assetsPath, lateName))).toBe(true)
+  })
+
+  it('cancels a scheduled run before rename or source deletion', async () => {
+    const paths = createPaths()
+    const fileName = 'abcdefghijklmnop.png'
+    writeLegacyAsset(paths, fileName, 'source')
+
+    scheduleNotesAssetsMigration(
+      createCache(paths, [createNote(1, assetUrl(fileName))]),
+    )
+    cancelNotesAssetsMigration()
+    await waitForNotesAssetsMigrationForTests()
+
+    expect(fs.pathExistsSync(path.join(paths.legacyAssetsPath, fileName))).toBe(
+      true,
+    )
+    expect(fs.pathExistsSync(path.join(paths.assetsPath, fileName))).toBe(
+      false,
+    )
+  })
+})

--- a/src/main/storage/providers/markdown/notes/runtime/__tests__/assetsMigration.test.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/__tests__/assetsMigration.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { setDatalessProbeForTests } from '../../../runtime/shared/cloudFiles'
+import { extractNotesAssetNames } from '../assetsInspection'
 import {
   cancelNotesAssetsMigration,
   discoverNotesAssetReferences,
@@ -114,6 +115,21 @@ afterEach(() => {
 })
 
 describe('notes assets migration discovery', () => {
+  it('extracts unique valid notes asset names from markdown source', () => {
+    const validName = 'abcdefghijklmnop.png'
+
+    expect([
+      ...extractNotesAssetNames(
+        [
+          assetUrl(validName),
+          assetUrl(validName),
+          'masscode://notes-asset/../invalid.png',
+          'masscode://notes-asset/not-an-asset.txt',
+        ].join(' '),
+      ),
+    ]).toEqual([validName])
+  })
+
   it('collects only valid references from available note content', () => {
     const paths = createPaths()
     const availableName = 'abcdefghijklmnop.png'

--- a/src/main/storage/providers/markdown/notes/runtime/__tests__/constants.test.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/__tests__/constants.test.ts
@@ -47,6 +47,12 @@ describe('getNotesPaths', () => {
       fs.pathExistsSync(path.join(notesPaths.notesRoot, 'Folder', 'note.md')),
     ).toBe(true)
     expect(fs.pathExistsSync(legacyNotesRoot)).toBe(false)
+    expect(notesPaths.assetsPath).toBe(
+      path.join(vaultPath, 'notes', '.masscode', 'assets'),
+    )
+    expect(notesPaths.legacyAssetsPath).toBe(
+      path.join(vaultPath, 'notes', 'assets'),
+    )
   })
 
   it('merges nested notes space into existing flat notes space', () => {

--- a/src/main/storage/providers/markdown/notes/runtime/__tests__/metadataIndex.test.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/__tests__/metadataIndex.test.ts
@@ -45,7 +45,9 @@ function createNotesPaths(): NotesPaths {
   const metaDirPath = path.join(notesRoot, '.masscode')
 
   return {
+    assetsPath: path.join(metaDirPath, 'assets'),
     inboxDirPath: path.join(metaDirPath, 'inbox'),
+    legacyAssetsPath: path.join(notesRoot, 'assets'),
     metaDirPath,
     notesRoot,
     statePath: path.join(metaDirPath, 'state.json'),

--- a/src/main/storage/providers/markdown/notes/runtime/__tests__/notes.test.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/__tests__/notes.test.ts
@@ -69,7 +69,9 @@ function createNotesPaths(): NotesPaths {
   const metaDirPath = path.join(notesRoot, '.masscode')
 
   return {
+    assetsPath: path.join(metaDirPath, 'assets'),
     inboxDirPath: path.join(metaDirPath, 'inbox'),
+    legacyAssetsPath: path.join(notesRoot, 'assets'),
     metaDirPath,
     notesRoot,
     statePath: path.join(metaDirPath, 'state.json'),

--- a/src/main/storage/providers/markdown/notes/runtime/__tests__/search.test.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/__tests__/search.test.ts
@@ -50,7 +50,9 @@ function createRuntimeCache(notes: MarkdownNote[]): NotesRuntimeCache {
     noteById: new Map(notes.map(note => [note.id, note])),
     notes,
     paths: {
+      assetsPath: '/tmp/meta/assets',
       inboxDirPath: '/tmp/inbox',
+      legacyAssetsPath: '/tmp/notes/assets',
       metaDirPath: '/tmp/meta',
       notesRoot: '/tmp/notes',
       statePath: '/tmp/state.json',

--- a/src/main/storage/providers/markdown/notes/runtime/__tests__/sync.test.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/__tests__/sync.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import fs from 'fs-extra'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { waitForNotesAssetsMigrationForTests } from '../assetsMigration'
 import { createDefaultNotesState, saveNotesState } from '../state'
 import {
   resetNotesRuntimeCache,
@@ -82,6 +83,7 @@ function createNotesPaths(): NotesPaths {
 }
 
 afterEach(() => {
+  resetNotesRuntimeCache()
   for (const dirPath of tempDirs.splice(0)) {
     fs.removeSync(dirPath)
   }
@@ -341,6 +343,49 @@ describe('syncNotesRuntimeWithDisk', () => {
 
     expect(cache.state.tags).toHaveLength(1)
     expect(cache.state.tags[0].name).toBe('pending-tag')
+  })
+
+  it('schedules referenced asset migration after a full sync', async () => {
+    const paths = createNotesPaths()
+    const fileName = 'abcdefghijklmnop.png'
+    fs.ensureDirSync(paths.legacyAssetsPath)
+    fs.writeFileSync(path.join(paths.legacyAssetsPath, fileName), 'asset')
+    fs.writeFileSync(
+      path.join(paths.notesRoot, 'Note.md'),
+      `---\nid: 1\nname: Note\n---\n![asset](masscode://notes-asset/${fileName})\n`,
+      'utf8',
+    )
+
+    syncNotesRuntimeWithDisk(paths)
+    await waitForNotesAssetsMigrationForTests()
+
+    expect(fs.pathExistsSync(path.join(paths.assetsPath, fileName))).toBe(true)
+    expect(fs.pathExistsSync(path.join(paths.legacyAssetsPath, fileName))).toBe(
+      false,
+    )
+  })
+
+  it('discovers a late reference after successful incremental note sync', async () => {
+    const paths = createNotesPaths()
+    const fileName = 'abcdefghijklmnop.png'
+    fs.ensureDirSync(paths.legacyAssetsPath)
+    fs.writeFileSync(path.join(paths.legacyAssetsPath, fileName), 'asset')
+
+    syncNotesRuntimeWithDisk(paths)
+    await waitForNotesAssetsMigrationForTests()
+
+    fs.writeFileSync(
+      path.join(paths.notesRoot, 'Late.md'),
+      `---\nid: 2\nname: Late\n---\n![asset](masscode://notes-asset/${fileName})\n`,
+      'utf8',
+    )
+    expect(syncNoteFileWithDisk(paths, 'Late.md')).not.toBeNull()
+    await waitForNotesAssetsMigrationForTests()
+
+    expect(fs.pathExistsSync(path.join(paths.assetsPath, fileName))).toBe(true)
+    expect(fs.pathExistsSync(path.join(paths.legacyAssetsPath, fileName))).toBe(
+      false,
+    )
   })
 })
 

--- a/src/main/storage/providers/markdown/notes/runtime/__tests__/sync.test.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/__tests__/sync.test.ts
@@ -71,7 +71,9 @@ function createNotesPaths(): NotesPaths {
   const metaDirPath = path.join(notesRoot, '.masscode')
 
   return {
+    assetsPath: path.join(metaDirPath, 'assets'),
     inboxDirPath: path.join(metaDirPath, 'inbox'),
+    legacyAssetsPath: path.join(notesRoot, 'assets'),
     metaDirPath,
     notesRoot,
     statePath: path.join(metaDirPath, 'state.json'),

--- a/src/main/storage/providers/markdown/notes/runtime/assets.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/assets.ts
@@ -1,0 +1,273 @@
+import type { NotesPaths } from './types'
+import { Buffer } from 'node:buffer'
+import { randomBytes } from 'node:crypto'
+import { constants as fsConstants } from 'node:fs'
+import { lstat, open, readFile, rename, rm } from 'node:fs/promises'
+import path from 'node:path'
+import fs from 'fs-extra'
+import { prioritizeCloudDownload } from '../../cloudDownloads'
+import { getFileAvailability } from '../../runtime/shared/cloudFiles'
+
+const ASSET_ID_LENGTHS = new Set([16, 21])
+const READER_MIME_BY_EXTENSION: Record<string, string> = {
+  '.bmp': 'image/bmp',
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+}
+const WRITER_EXTENSIONS = new Set(['.jpeg', '.jpg', '.png'])
+const SAFE_RESPONSE_HEADERS = {
+  'Cache-Control': 'no-store',
+  'X-Content-Type-Options': 'nosniff',
+}
+
+export interface ParsedNotesAssetName {
+  extension: string
+  fileName: string
+  mimeType: string
+}
+
+export interface NotesAssetWritePayload {
+  buffer: ArrayBuffer
+  ext: string
+}
+
+export function parseNotesAssetWritePayload(
+  payload: unknown,
+): NotesAssetWritePayload | null {
+  if (!payload || typeof payload !== 'object') {
+    return null
+  }
+
+  const candidate = payload as { buffer?: unknown, ext?: unknown }
+  if (
+    typeof candidate.ext !== 'string'
+    || !(candidate.buffer instanceof ArrayBuffer)
+  ) {
+    return null
+  }
+
+  return { buffer: candidate.buffer, ext: candidate.ext }
+}
+
+function hasExpectedImageSignature(data: Buffer, extension: string): boolean {
+  if (extension === '.png') {
+    return data
+      .subarray(0, 8)
+      .equals(Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]))
+  }
+
+  if (extension === '.jpg' || extension === '.jpeg') {
+    return (
+      data.length >= 3
+      && data[0] === 0xFF
+      && data[1] === 0xD8
+      && data[2] === 0xFF
+    )
+  }
+
+  return false
+}
+
+export function parseNotesAssetName(
+  value: string,
+): ParsedNotesAssetName | null {
+  let fileName: string
+  try {
+    fileName = decodeURIComponent(value)
+  }
+  catch {
+    return null
+  }
+
+  if (
+    fileName !== path.basename(fileName)
+    || fileName.includes('/')
+    || fileName.includes('\\')
+    || fileName.includes('..')
+  ) {
+    return null
+  }
+
+  const extension = path.extname(fileName).toLowerCase()
+  const stem = fileName.slice(0, -extension.length)
+  const mimeType = READER_MIME_BY_EXTENSION[extension]
+
+  if (
+    !mimeType
+    || !ASSET_ID_LENGTHS.has(stem.length)
+    || !/^[\w-]+$/.test(stem)
+  ) {
+    return null
+  }
+
+  return { extension, fileName, mimeType }
+}
+
+export function getNotesAssetNameFromAbsolutePath(
+  paths: NotesPaths,
+  absolutePath: string,
+): string | null {
+  const parentPath = path.resolve(path.dirname(absolutePath))
+  if (
+    parentPath !== path.resolve(paths.assetsPath)
+    && parentPath !== path.resolve(paths.legacyAssetsPath)
+  ) {
+    return null
+  }
+
+  return parseNotesAssetName(path.basename(absolutePath))?.fileName ?? null
+}
+
+export function normalizeNotesAssetWriterExtension(
+  value: string,
+): string | null {
+  const extension = value.toLowerCase()
+  return WRITER_EXTENSIONS.has(extension) ? extension : null
+}
+
+function generateAssetId(): string {
+  return randomBytes(12).toString('base64url')
+}
+
+export async function writeNotesAsset(
+  paths: NotesPaths,
+  payload: ArrayBuffer,
+  requestedExtension: string,
+  generateId: () => string = generateAssetId,
+): Promise<string> {
+  const extension = normalizeNotesAssetWriterExtension(requestedExtension)
+  if (!extension) {
+    throw new Error('Unsupported Notes asset extension')
+  }
+
+  const data = Buffer.from(payload)
+  if (!hasExpectedImageSignature(data, extension)) {
+    throw new Error('Notes asset payload does not match its extension')
+  }
+
+  const fileName = `${generateId()}${extension}`
+  const parsedName = parseNotesAssetName(fileName)
+  if (!parsedName) {
+    throw new Error('Invalid generated Notes asset name')
+  }
+
+  await fs.ensureDir(paths.assetsPath)
+  const destinationPath = path.join(paths.assetsPath, parsedName.fileName)
+  const destinationAvailability = getFileAvailability(destinationPath)
+  if (destinationAvailability.exists) {
+    throw new Error('Notes asset destination already exists')
+  }
+
+  const tempPath = path.join(
+    paths.assetsPath,
+    `.${parsedName.fileName}.${randomBytes(8).toString('hex')}.tmp`,
+  )
+  let tempCreated = false
+
+  try {
+    const handle = await open(
+      tempPath,
+      fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+      0o600,
+    )
+    tempCreated = true
+    try {
+      await handle.writeFile(data)
+    }
+    finally {
+      await handle.close()
+    }
+
+    if (getFileAvailability(destinationPath).exists) {
+      throw new Error('Notes asset destination already exists')
+    }
+
+    await rename(tempPath, destinationPath)
+    tempCreated = false
+    return `masscode://notes-asset/${parsedName.fileName}`
+  }
+  finally {
+    if (tempCreated) {
+      await rm(tempPath, { force: true })
+    }
+  }
+}
+
+function unavailableResponse(): Response {
+  return new Response('Temporarily unavailable', {
+    headers: {
+      ...SAFE_RESPONSE_HEADERS,
+      'Retry-After': '1',
+    },
+    status: 503,
+  })
+}
+
+function notFoundResponse(): Response {
+  return new Response('Not found', {
+    headers: SAFE_RESPONSE_HEADERS,
+    status: 404,
+  })
+}
+
+export async function resolveNotesAsset(
+  rawFileName: string,
+  paths: NotesPaths,
+  prioritizeDownload: (absolutePath: string) => void = prioritizeCloudDownload,
+): Promise<Response> {
+  const parsedName = parseNotesAssetName(rawFileName)
+  if (!parsedName) {
+    return notFoundResponse()
+  }
+
+  for (const rootPath of [paths.assetsPath, paths.legacyAssetsPath]) {
+    const absolutePath = path.join(rootPath, parsedName.fileName)
+    try {
+      if ((await lstat(absolutePath)).isSymbolicLink()) {
+        return notFoundResponse()
+      }
+    }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        continue
+      }
+      return notFoundResponse()
+    }
+
+    const availability = getFileAvailability(absolutePath)
+
+    if (!availability.exists) {
+      continue
+    }
+
+    if (!availability.stats?.isFile()) {
+      return notFoundResponse()
+    }
+
+    if (availability.isCloudPlaceholder) {
+      prioritizeDownload(absolutePath)
+      return unavailableResponse()
+    }
+
+    try {
+      const data = await readFile(absolutePath)
+      const headers: Record<string, string> = {
+        ...SAFE_RESPONSE_HEADERS,
+        'Content-Type': parsedName.mimeType,
+      }
+      if (parsedName.extension === '.svg') {
+        headers['Content-Security-Policy'] = 'default-src \'none\'; sandbox'
+      }
+      return new Response(data, { headers })
+    }
+    catch {
+      return notFoundResponse()
+    }
+  }
+
+  return notFoundResponse()
+}

--- a/src/main/storage/providers/markdown/notes/runtime/assetsInspection.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/assetsInspection.ts
@@ -1,0 +1,16 @@
+import { parseNotesAssetName } from './assets'
+
+const NOTES_ASSET_URL_PATTERN = /masscode:\/\/notes-asset\/([^\s)<>'"]+)/g
+
+export function extractNotesAssetNames(source: string): Set<string> {
+  const fileNames = new Set<string>()
+
+  for (const match of source.matchAll(NOTES_ASSET_URL_PATTERN)) {
+    const parsedName = parseNotesAssetName(match[1])
+    if (parsedName) {
+      fileNames.add(parsedName.fileName)
+    }
+  }
+
+  return fileNames
+}

--- a/src/main/storage/providers/markdown/notes/runtime/assetsMigration.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/assetsMigration.ts
@@ -1,0 +1,493 @@
+import type { Stats } from 'node:fs'
+import type { NotesRuntimeCache } from './types'
+import { createHash, randomBytes } from 'node:crypto'
+import { constants as fsConstants } from 'node:fs'
+import {
+  copyFile,
+  link,
+  lstat,
+  open,
+  readFile,
+  rm,
+  unlink,
+} from 'node:fs/promises'
+import path from 'node:path'
+import fs from 'fs-extra'
+import { log } from '../../../../../utils'
+import {
+  enqueueCloudDownload,
+  prioritizeCloudDownload,
+} from '../../cloudDownloads'
+import { getFileAvailability } from '../../runtime/shared/cloudFiles'
+import { parseNotesAssetName } from './assets'
+import { ensureNoteContentLoaded } from './notes'
+
+const NOTES_ASSET_URL_PATTERN = /masscode:\/\/notes-asset\/([^\s)<>'"]+)/g
+
+export interface NotesAssetsMigrationSummary {
+  conflicts: number
+  deferred: number
+  errors: number
+  migrated: number
+  referenced: number
+  removedEqual: number
+}
+
+export interface NotesAssetReferenceDiscovery {
+  complete: boolean
+  fileNames: Set<string>
+}
+
+interface NotesAssetsMigrationHooks {
+  afterFinalDestinationHash?: (paths: {
+    destinationPath: string
+    sourcePath: string
+    tempPath?: string
+  }) => Promise<void> | void
+  afterPublish?: (paths: {
+    destinationPath: string
+    sourcePath: string
+    tempPath: string
+  }) => Promise<void> | void
+  beforePublish?: (paths: {
+    destinationPath: string
+    sourcePath: string
+    tempPath: string
+  }) => Promise<void> | void
+}
+
+type MigrationOutcome =
+  | 'conflict'
+  | 'deferred'
+  | 'migrated'
+  | 'missing'
+  | 'removed-equal'
+
+let migrationGeneration = 0
+let activeMigration: Promise<void> | null = null
+let pendingCache: NotesRuntimeCache | null = null
+
+function isDirectFilePath(rootPath: string, filePath: string): boolean {
+  return path.dirname(filePath) === rootPath
+}
+
+async function assertDirectRegularFile(
+  rootPath: string,
+  filePath: string,
+): Promise<Stats> {
+  if (!isDirectFilePath(rootPath, filePath)) {
+    throw new Error('Notes asset migration path is not direct')
+  }
+
+  const stats = await lstat(filePath)
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    throw new Error('Notes asset migration source is not a regular file')
+  }
+  return stats
+}
+
+async function hashFile(filePath: string): Promise<string> {
+  const data = await readFile(filePath)
+  return createHash('sha256').update(data).digest('hex')
+}
+
+async function verifyAndDeleteSource(
+  sourceRootPath: string,
+  sourcePath: string,
+  destinationPath: string,
+  expectedHash: string,
+  isCancelled: () => boolean,
+  hooks: NotesAssetsMigrationHooks,
+  tempPath?: string,
+): Promise<'conflict' | 'deferred' | 'removed'> {
+  const destinationStatsBefore = await assertDirectRegularFile(
+    path.dirname(destinationPath),
+    destinationPath,
+  )
+  if (tempPath) {
+    const tempStats = await lstat(tempPath)
+    if (
+      tempStats.dev !== destinationStatsBefore.dev
+      || tempStats.ino !== destinationStatsBefore.ino
+    ) {
+      return 'conflict'
+    }
+  }
+
+  const destinationHash = await hashFile(destinationPath)
+  await hooks.afterFinalDestinationHash?.({
+    destinationPath,
+    sourcePath,
+    ...(tempPath ? { tempPath } : {}),
+  })
+  if (destinationHash !== expectedHash) {
+    return 'conflict'
+  }
+
+  const destinationStatsAfter = await assertDirectRegularFile(
+    path.dirname(destinationPath),
+    destinationPath,
+  )
+  if (
+    destinationStatsAfter.dev !== destinationStatsBefore.dev
+    || destinationStatsAfter.ino !== destinationStatsBefore.ino
+  ) {
+    return 'conflict'
+  }
+
+  await assertDirectRegularFile(sourceRootPath, sourcePath)
+  if ((await hashFile(sourcePath)) !== expectedHash) {
+    return 'conflict'
+  }
+
+  if (isCancelled()) {
+    return 'deferred'
+  }
+  await unlink(sourcePath)
+  return 'removed'
+}
+
+async function removePublishedDestinationIfOwned(
+  tempPath: string,
+  destinationPath: string,
+): Promise<void> {
+  try {
+    const [tempStats, destinationStats] = await Promise.all([
+      lstat(tempPath),
+      lstat(destinationPath),
+    ])
+    if (
+      tempStats.dev === destinationStats.dev
+      && tempStats.ino === destinationStats.ino
+    ) {
+      await unlink(destinationPath)
+    }
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      log('storage:notes:assets-migration-cleanup', error)
+    }
+  }
+}
+
+async function evaluateExistingDestination(
+  cache: NotesRuntimeCache,
+  sourcePath: string,
+  destinationPath: string,
+  sourceHash: string,
+  isCancelled: () => boolean,
+  hooks: NotesAssetsMigrationHooks,
+): Promise<MigrationOutcome | null> {
+  const availability = getFileAvailability(destinationPath)
+  if (!availability.exists) {
+    return null
+  }
+
+  await assertDirectRegularFile(cache.paths.assetsPath, destinationPath)
+  if (availability.isCloudPlaceholder) {
+    prioritizeCloudDownload(destinationPath)
+    return 'deferred'
+  }
+
+  const deletion = await verifyAndDeleteSource(
+    cache.paths.legacyAssetsPath,
+    sourcePath,
+    destinationPath,
+    sourceHash,
+    isCancelled,
+    hooks,
+  )
+  if (deletion === 'removed') {
+    return 'removed-equal'
+  }
+  return deletion
+}
+
+export function discoverNotesAssetReferences(
+  cache: NotesRuntimeCache,
+): NotesAssetReferenceDiscovery {
+  const fileNames = new Set<string>()
+  let complete = true
+
+  for (const note of cache.notes) {
+    if (note.pendingCloudDownload) {
+      enqueueCloudDownload(path.join(cache.paths.notesRoot, note.filePath))
+      complete = false
+      continue
+    }
+
+    if (note.content === null && !ensureNoteContentLoaded(cache.paths, note)) {
+      complete = false
+      continue
+    }
+
+    if (note.content === null) {
+      complete = false
+      continue
+    }
+
+    for (const match of note.content.matchAll(NOTES_ASSET_URL_PATTERN)) {
+      const parsedName = parseNotesAssetName(match[1])
+      if (parsedName) {
+        fileNames.add(parsedName.fileName)
+      }
+    }
+  }
+
+  return { complete, fileNames }
+}
+
+async function migrateReferencedAsset(
+  cache: NotesRuntimeCache,
+  fileName: string,
+  isCancelled: () => boolean,
+  hooks: NotesAssetsMigrationHooks,
+): Promise<MigrationOutcome> {
+  if (isCancelled()) {
+    return 'deferred'
+  }
+
+  const sourcePath = path.join(cache.paths.legacyAssetsPath, fileName)
+  const destinationPath = path.join(cache.paths.assetsPath, fileName)
+  const sourceAvailability = getFileAvailability(sourcePath)
+
+  if (!sourceAvailability.exists) {
+    return 'missing'
+  }
+  await assertDirectRegularFile(cache.paths.legacyAssetsPath, sourcePath)
+  if (isCancelled()) {
+    return 'deferred'
+  }
+
+  const destinationAvailability = getFileAvailability(destinationPath)
+  if (destinationAvailability.exists) {
+    await assertDirectRegularFile(cache.paths.assetsPath, destinationPath)
+    if (isCancelled()) {
+      return 'deferred'
+    }
+  }
+
+  let shouldDeferForHydration = false
+  if (sourceAvailability.isCloudPlaceholder) {
+    prioritizeCloudDownload(sourcePath)
+    shouldDeferForHydration = true
+  }
+  if (
+    destinationAvailability.exists
+    && destinationAvailability.isCloudPlaceholder
+  ) {
+    prioritizeCloudDownload(destinationPath)
+    shouldDeferForHydration = true
+  }
+  if (shouldDeferForHydration) {
+    return 'deferred'
+  }
+
+  if (destinationAvailability.exists) {
+    const sourceHash = await hashFile(sourcePath)
+    return (
+      (await evaluateExistingDestination(
+        cache,
+        sourcePath,
+        destinationPath,
+        sourceHash,
+        isCancelled,
+        hooks,
+      )) ?? 'deferred'
+    )
+  }
+
+  const sourceHash = await hashFile(sourcePath)
+  if (isCancelled()) {
+    return 'deferred'
+  }
+
+  await fs.ensureDir(cache.paths.assetsPath)
+  const tempPath = path.join(
+    cache.paths.assetsPath,
+    `.${fileName}.${randomBytes(8).toString('hex')}.migration.tmp`,
+  )
+  let tempCreated = false
+  let shouldCleanupPublishedDestination = false
+
+  try {
+    const tempHandle = await open(
+      tempPath,
+      fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+      0o600,
+    )
+    tempCreated = true
+    await tempHandle.close()
+
+    await copyFile(sourcePath, tempPath)
+    if ((await hashFile(tempPath)) !== sourceHash) {
+      throw new Error('Notes asset migration temp hash mismatch')
+    }
+
+    if (isCancelled()) {
+      return 'deferred'
+    }
+
+    await hooks.beforePublish?.({
+      destinationPath,
+      sourcePath,
+      tempPath,
+    })
+
+    try {
+      await link(tempPath, destinationPath)
+    }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw error
+      }
+
+      return (
+        (await evaluateExistingDestination(
+          cache,
+          sourcePath,
+          destinationPath,
+          sourceHash,
+          isCancelled,
+          hooks,
+        )) ?? 'deferred'
+      )
+    }
+
+    shouldCleanupPublishedDestination = true
+    await hooks.afterPublish?.({
+      destinationPath,
+      sourcePath,
+      tempPath,
+    })
+
+    const deletion = await verifyAndDeleteSource(
+      cache.paths.legacyAssetsPath,
+      sourcePath,
+      destinationPath,
+      sourceHash,
+      isCancelled,
+      hooks,
+      tempPath,
+    )
+    if (deletion === 'conflict') {
+      return 'conflict'
+    }
+    shouldCleanupPublishedDestination = false
+    return deletion === 'removed' ? 'migrated' : 'deferred'
+  }
+  finally {
+    if (shouldCleanupPublishedDestination) {
+      await removePublishedDestinationIfOwned(tempPath, destinationPath)
+    }
+    if (tempCreated) {
+      await rm(tempPath, { force: true })
+    }
+  }
+}
+
+async function runNotesAssetsMigrationInternal(
+  cache: NotesRuntimeCache,
+  isCancelled: () => boolean,
+  hooks: NotesAssetsMigrationHooks,
+): Promise<NotesAssetsMigrationSummary> {
+  const discovery = discoverNotesAssetReferences(cache)
+  const summary: NotesAssetsMigrationSummary = {
+    conflicts: 0,
+    deferred: discovery.complete ? 0 : 1,
+    errors: 0,
+    migrated: 0,
+    referenced: discovery.fileNames.size,
+    removedEqual: 0,
+  }
+
+  for (const fileName of discovery.fileNames) {
+    if (isCancelled()) {
+      summary.deferred += 1
+      break
+    }
+
+    try {
+      const outcome = await migrateReferencedAsset(
+        cache,
+        fileName,
+        isCancelled,
+        hooks,
+      )
+      if (outcome === 'conflict') {
+        summary.conflicts += 1
+      }
+      else if (outcome === 'deferred') {
+        summary.deferred += 1
+      }
+      else if (outcome === 'migrated') {
+        summary.migrated += 1
+      }
+      else if (outcome === 'removed-equal') {
+        summary.removedEqual += 1
+      }
+    }
+    catch (error) {
+      summary.errors += 1
+      log('storage:notes:assets-migration-item', error)
+    }
+  }
+
+  return summary
+}
+
+export async function runNotesAssetsMigration(
+  cache: NotesRuntimeCache,
+  isCancelled: () => boolean = () => false,
+): Promise<NotesAssetsMigrationSummary> {
+  return runNotesAssetsMigrationInternal(cache, isCancelled, {})
+}
+
+// Test-only fault injection entrypoint; intentionally omitted from runtime/index.
+export async function runNotesAssetsMigrationForTests(
+  cache: NotesRuntimeCache,
+  isCancelled: () => boolean = () => false,
+  hooks: NotesAssetsMigrationHooks = {},
+): Promise<NotesAssetsMigrationSummary> {
+  return runNotesAssetsMigrationInternal(cache, isCancelled, hooks)
+}
+
+export function scheduleNotesAssetsMigration(cache: NotesRuntimeCache): void {
+  pendingCache = cache
+  if (activeMigration) {
+    return
+  }
+
+  const generation = migrationGeneration
+  const drain = async (): Promise<void> => {
+    while (pendingCache) {
+      if (generation !== migrationGeneration) {
+        break
+      }
+      const nextCache = pendingCache
+      pendingCache = null
+      await runNotesAssetsMigration(
+        nextCache,
+        () => generation !== migrationGeneration,
+      )
+    }
+  }
+
+  activeMigration = drain()
+    .catch(error => log('storage:notes:assets-migration', error))
+    .finally(() => {
+      activeMigration = null
+      if (pendingCache) {
+        scheduleNotesAssetsMigration(pendingCache)
+      }
+    })
+}
+
+export function cancelNotesAssetsMigration(): void {
+  migrationGeneration += 1
+  pendingCache = null
+}
+
+export async function waitForNotesAssetsMigrationForTests(): Promise<void> {
+  await activeMigration
+}

--- a/src/main/storage/providers/markdown/notes/runtime/assetsMigration.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/assetsMigration.ts
@@ -19,10 +19,8 @@ import {
   prioritizeCloudDownload,
 } from '../../cloudDownloads'
 import { getFileAvailability } from '../../runtime/shared/cloudFiles'
-import { parseNotesAssetName } from './assets'
+import { extractNotesAssetNames } from './assetsInspection'
 import { ensureNoteContentLoaded } from './notes'
-
-const NOTES_ASSET_URL_PATTERN = /masscode:\/\/notes-asset\/([^\s)<>'"]+)/g
 
 export interface NotesAssetsMigrationSummary {
   conflicts: number
@@ -226,11 +224,8 @@ export function discoverNotesAssetReferences(
       continue
     }
 
-    for (const match of note.content.matchAll(NOTES_ASSET_URL_PATTERN)) {
-      const parsedName = parseNotesAssetName(match[1])
-      if (parsedName) {
-        fileNames.add(parsedName.fileName)
-      }
+    for (const fileName of extractNotesAssetNames(note.content)) {
+      fileNames.add(fileName)
     }
   }
 

--- a/src/main/storage/providers/markdown/notes/runtime/constants.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/constants.ts
@@ -16,6 +16,9 @@ export { INBOX_DIR_NAME, META_DIR_NAME, META_FILE_NAME, TRASH_DIR_NAME }
 
 export const NOTES_INBOX_RELATIVE_PATH = `${META_DIR_NAME}/${INBOX_DIR_NAME}`
 export const NOTES_TRASH_RELATIVE_PATH = `${META_DIR_NAME}/${TRASH_DIR_NAME}`
+export const NOTES_ASSETS_DIR_NAME = 'assets'
+export const NOTES_ASSETS_RELATIVE_PATH = `${META_DIR_NAME}/${NOTES_ASSETS_DIR_NAME}`
+export const NOTES_LEGACY_ASSETS_RELATIVE_PATH = NOTES_ASSETS_DIR_NAME
 
 export const NOTES_RESERVED_ROOT_NAMES = new Set([
   INBOX_DIR_NAME,
@@ -74,7 +77,9 @@ export function getNotesPaths(vaultPath: string): NotesPaths {
   const metaDirPath = path.join(notesRoot, META_DIR_NAME)
 
   const notesPaths: NotesPaths = {
+    assetsPath: path.join(metaDirPath, NOTES_ASSETS_DIR_NAME),
     inboxDirPath: path.join(metaDirPath, INBOX_DIR_NAME),
+    legacyAssetsPath: path.join(notesRoot, NOTES_ASSETS_DIR_NAME),
     metaDirPath,
     notesRoot,
     statePath: path.join(metaDirPath, 'state.json'),

--- a/src/main/storage/providers/markdown/notes/runtime/index.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/index.ts
@@ -1,4 +1,5 @@
 export * from './assets'
+export * from './assetsInspection'
 export {
   cancelNotesAssetsMigration,
   discoverNotesAssetReferences,

--- a/src/main/storage/providers/markdown/notes/runtime/index.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/index.ts
@@ -1,3 +1,4 @@
+export * from './assets'
 export * from './constants'
 export * from './notes'
 export * from './parser'

--- a/src/main/storage/providers/markdown/notes/runtime/index.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/index.ts
@@ -1,4 +1,14 @@
 export * from './assets'
+export {
+  cancelNotesAssetsMigration,
+  discoverNotesAssetReferences,
+  runNotesAssetsMigration,
+  scheduleNotesAssetsMigration,
+} from './assetsMigration'
+export type {
+  NotesAssetReferenceDiscovery,
+  NotesAssetsMigrationSummary,
+} from './assetsMigration'
 export * from './constants'
 export * from './notes'
 export * from './parser'

--- a/src/main/storage/providers/markdown/notes/runtime/sync.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/sync.ts
@@ -264,7 +264,14 @@ function buildProvisionalNotesCache(paths: NotesPaths): NotesRuntimeCache {
 
 // Настоящая сверка с диском: может бросить, если .state.yaml сам недокачан
 // из облака (reconciler ретраит по этой ошибке).
-function performFullNotesSync(paths: NotesPaths): NotesRuntimeCache {
+export interface SyncNotesRuntimeOptions {
+  scheduleAssetsMigration?: boolean
+}
+
+function performFullNotesSync(
+  paths: NotesPaths,
+  options: SyncNotesRuntimeOptions,
+): NotesRuntimeCache {
   flushPendingNotesStateWrite(paths)
   const state = loadNotesState(paths)
 
@@ -286,11 +293,16 @@ function performFullNotesSync(paths: NotesPaths): NotesRuntimeCache {
   saveNotesState(paths, state, { immediate: true })
 
   const cache = setNotesRuntimeCache(paths, state, notes)
-  scheduleNotesAssetsMigration(cache)
+  if (options.scheduleAssetsMigration !== false) {
+    scheduleNotesAssetsMigration(cache)
+  }
   return cache
 }
 
-export function syncNotesRuntimeWithDisk(paths: NotesPaths): NotesRuntimeCache {
+export function syncNotesRuntimeWithDisk(
+  paths: NotesPaths,
+  options: SyncNotesRuntimeOptions = {},
+): NotesRuntimeCache {
   // Первый доступ к vault: обход диска опасен синхронно (листинги
   // dataless-каталогов материализуются сетью), поэтому мгновенно отдаётся
   // provisional-кэш, а настоящая сверка выполняется в фоне.
@@ -305,13 +317,13 @@ export function syncNotesRuntimeWithDisk(paths: NotesPaths): NotesRuntimeCache {
         return
       }
 
-      performFullNotesSync(paths)
+      performFullNotesSync(paths, options)
     })
 
     return provisionalCache
   }
 
-  return performFullNotesSync(paths)
+  return performFullNotesSync(paths, options)
 }
 
 // Перепроверка недокачанных заметок независимо от fs-событий: см.

--- a/src/main/storage/providers/markdown/notes/runtime/sync.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/sync.ts
@@ -22,6 +22,10 @@ import {
 import { isCloudFileNotDownloadedError } from '../../runtime/shared/guardedRead'
 import { normalizeDirectoryPath, toPosixPath } from '../../runtime/shared/path'
 import { createVaultReconciler } from '../../runtime/shared/vaultReconcile'
+import {
+  cancelNotesAssetsMigration,
+  scheduleNotesAssetsMigration,
+} from './assetsMigration'
 import { applyDeferredBacklinkRewrites } from './backlinks'
 import {
   NOTES_INBOX_RELATIVE_PATH,
@@ -281,7 +285,9 @@ function performFullNotesSync(paths: NotesPaths): NotesRuntimeCache {
 
   saveNotesState(paths, state, { immediate: true })
 
-  return setNotesRuntimeCache(paths, state, notes)
+  const cache = setNotesRuntimeCache(paths, state, notes)
+  scheduleNotesAssetsMigration(cache)
+  return cache
 }
 
 export function syncNotesRuntimeWithDisk(paths: NotesPaths): NotesRuntimeCache {
@@ -354,6 +360,7 @@ export function getNotesRuntimeCache(paths: NotesPaths): NotesRuntimeCache {
 }
 
 export function resetNotesRuntimeCache(): void {
+  cancelNotesAssetsMigration()
   // Смена vault: ретраи сверки брошенного корня останавливаются, иначе они
   // продолжили бы попытки по неактивному пути и слали storage-synced.
   const previousNotesRoot = notesRuntimeRef.cache?.paths.notesRoot
@@ -369,6 +376,7 @@ function commitNotesRuntimeCache(cache: NotesRuntimeCache): NotesRuntimeCache {
   // A new object identity signals watcher consumers that data changed,
   // while built maps and the lazily rebuilt search index are reused.
   notesRuntimeRef.cache = { ...cache }
+  scheduleNotesAssetsMigration(notesRuntimeRef.cache)
   return notesRuntimeRef.cache
 }
 

--- a/src/main/storage/providers/markdown/notes/runtime/types.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/types.ts
@@ -2,7 +2,9 @@ import type { InternalLinkLookupItem } from '../../../../../../shared/notes/inte
 import type { SearchIndex } from '../../runtime/shared/searchEngine'
 
 export interface NotesPaths {
+  assetsPath: string
   inboxDirPath: string
+  legacyAssetsPath: string
   metaDirPath: string
   notesRoot: string
   statePath: string

--- a/src/main/storage/providers/markdown/notes/storages/__tests__/folders.test.ts
+++ b/src/main/storage/providers/markdown/notes/storages/__tests__/folders.test.ts
@@ -83,7 +83,9 @@ describe('folders storage validations', () => {
     const metaDirPath = path.join(notesRoot, '.masscode')
 
     ensureNotesStateFile({
+      assetsPath: path.join(metaDirPath, 'assets'),
       inboxDirPath: path.join(metaDirPath, 'inbox'),
+      legacyAssetsPath: path.join(notesRoot, 'assets'),
       metaDirPath,
       notesRoot,
       statePath: path.join(metaDirPath, 'state.json'),

--- a/src/main/storage/providers/markdown/notes/storages/__tests__/notes.test.ts
+++ b/src/main/storage/providers/markdown/notes/storages/__tests__/notes.test.ts
@@ -88,7 +88,9 @@ describe('notes storage validations', () => {
     const metaDirPath = path.join(notesRoot, '.masscode')
 
     ensureNotesStateFile({
+      assetsPath: path.join(metaDirPath, 'assets'),
       inboxDirPath: path.join(metaDirPath, 'inbox'),
+      legacyAssetsPath: path.join(notesRoot, 'assets'),
       metaDirPath,
       notesRoot,
       statePath: path.join(metaDirPath, 'state.json'),

--- a/src/main/storage/providers/markdown/notesAssetEvents.ts
+++ b/src/main/storage/providers/markdown/notesAssetEvents.ts
@@ -1,0 +1,7 @@
+import { BrowserWindow } from 'electron'
+
+export function broadcastNotesAssetReady(fileName: string): void {
+  BrowserWindow.getAllWindows().forEach((window) => {
+    window.webContents.send('system:notes-asset-ready', fileName)
+  })
+}

--- a/src/main/storage/providers/markdown/runtime/__tests__/moveVault.test.ts
+++ b/src/main/storage/providers/markdown/runtime/__tests__/moveVault.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import os from 'node:os'
 import path from 'node:path'
 import fs from 'fs-extra'
@@ -60,6 +61,18 @@ describe('moveVault', () => {
     fs.writeFileSync(path.join(sourcePath, 'code', 'snippet.md'), '# Snippet')
     fs.ensureDirSync(path.join(sourcePath, 'notes'))
     fs.writeFileSync(path.join(sourcePath, 'notes', 'note.md'), '# Note')
+    const assetBytes = Buffer.from([0x00, 0xFF, 0x41, 0x80])
+    fs.ensureDirSync(path.join(sourcePath, 'notes', '.masscode', 'assets'))
+    fs.writeFileSync(
+      path.join(
+        sourcePath,
+        'notes',
+        '.masscode',
+        'assets',
+        'abcdefghijklmnop.png',
+      ),
+      assetBytes,
+    )
 
     moveVault(sourcePath, targetPath)
 
@@ -69,6 +82,17 @@ describe('moveVault', () => {
     expect(fs.pathExistsSync(path.join(targetPath, 'notes', 'note.md'))).toBe(
       true,
     )
+    expect(
+      fs.readFileSync(
+        path.join(
+          targetPath,
+          'notes',
+          '.masscode',
+          'assets',
+          'abcdefghijklmnop.png',
+        ),
+      ),
+    ).toEqual(assetBytes)
     expect(fs.pathExistsSync(sourcePath)).toBe(false)
   })
 

--- a/src/main/storage/providers/markdown/watcher.ts
+++ b/src/main/storage/providers/markdown/watcher.ts
@@ -23,6 +23,7 @@ import {
   refreshPendingNoteFiles,
   resetNotesPathsCache,
   resetNotesRuntimeCache,
+  scheduleNotesAssetsMigration,
   syncNoteFileWithDisk,
   syncNotesRuntimeWithDisk,
 } from './notes/runtime'
@@ -518,6 +519,10 @@ function initializeMarkdownWatcher(vaultRootPath: string): void {
       )
       if (assetName) {
         broadcastNotesAssetReady(assetName)
+        const notesCache = peekNotesRuntimeCache()
+        if (notesCache?.paths.notesRoot === notesPaths.notesRoot) {
+          scheduleNotesAssetsMigration(notesCache)
+        }
         return
       }
 
@@ -530,7 +535,12 @@ function initializeMarkdownWatcher(vaultRootPath: string): void {
         return
       }
 
-      scheduleStateSync(vaultRootPath, paths, relativeWatchPath)
+      scheduleStateSync(
+        vaultRootPath,
+        paths,
+        relativeWatchPath,
+        isNotesWatchPath(relativeWatchPath),
+      )
     },
     onQueueActivity: () => {
       scheduleCloudRefresh(vaultRootPath, paths, notesPaths, httpPaths)

--- a/src/main/storage/providers/markdown/watcher.ts
+++ b/src/main/storage/providers/markdown/watcher.ts
@@ -16,7 +16,9 @@ import {
   syncHttpRuntimeWithDisk,
 } from './http'
 import {
+  getNotesAssetNameFromAbsolutePath,
   getNotesPaths,
+  parseNotesAssetName,
   peekNotesRuntimeCache,
   refreshPendingNoteFiles,
   resetNotesPathsCache,
@@ -24,6 +26,7 @@ import {
   syncNoteFileWithDisk,
   syncNotesRuntimeWithDisk,
 } from './notes/runtime'
+import { broadcastNotesAssetReady } from './notesAssetEvents'
 import {
   ensureStateFile,
   getPaths,
@@ -42,10 +45,12 @@ import { getFileAvailability } from './runtime/shared/cloudFiles'
 import { isCloudFileNotDownloadedError } from './runtime/shared/guardedRead'
 import { broadcastStorageSynced } from './runtime/shared/vaultReconcile'
 import {
+  getManagedNotesAssetName,
   getWatchPathSpaceId,
   isCodeWatchPath,
   isDrawingsWatchPath,
   isHttpWatchPath,
+  isManagedNotesAssetsPath,
   isMathWatchPath,
   isNotesWatchPath,
   normalizeRelativeWatchPath,
@@ -80,6 +85,8 @@ let hasPendingHttpSync = false
 let hasPendingDrawingsSync = false
 let watcherStartToken = 0
 let chokidarWatchLoader: Promise<ChokidarWatch> | null = null
+let preparedCloudVaultPath: string | null = null
+let preparedWatcherStartToken: number | null = null
 
 type ChokidarWatch = (
   path: string | readonly string[],
@@ -153,6 +160,17 @@ function scheduleStateSync(
   changedPath: string | null,
   forceFullSync = false,
 ): void {
+  if (isManagedNotesAssetsPath(changedPath)) {
+    const managedAssetName = getManagedNotesAssetName(changedPath)
+    const parsedAsset = managedAssetName
+      ? parseNotesAssetName(managedAssetName)
+      : null
+    if (parsedAsset) {
+      broadcastNotesAssetReady(parsedAsset.fileName)
+    }
+    return
+  }
+
   const changedSpaceId = getWatchPathSpaceId(changedPath)
   if (changedPath && !changedSpaceId) {
     return
@@ -404,6 +422,8 @@ function scheduleCloudRefresh(
 
 export function stopMarkdownWatcher(): void {
   watcherStartToken += 1
+  preparedCloudVaultPath = null
+  preparedWatcherStartToken = null
 
   if (markdownWatchTimer) {
     clearTimeout(markdownWatchTimer)
@@ -439,6 +459,17 @@ export function stopMarkdownWatcher(): void {
 }
 
 function initializeMarkdownWatcher(vaultRootPath: string): void {
+  const canReusePreparedCloudQueue
+    = preparedCloudVaultPath === vaultRootPath
+      && preparedWatcherStartToken === watcherStartToken
+      && markdownWatcher === null
+      && watchedVaultPath === null
+
+  // Право сохранить раннюю очередь одноразовое: повторный start, даже пока
+  // первый ещё ждёт chokidar или cloud bootstrap, снова проходит stop/reset.
+  preparedCloudVaultPath = null
+  preparedWatcherStartToken = null
+
   const paths = getPaths(vaultRootPath)
   const runtimeCache = peekRuntimeCache()
   const notesPaths = getNotesPaths(vaultRootPath)
@@ -469,7 +500,9 @@ function initializeMarkdownWatcher(vaultRootPath: string): void {
     return
   }
 
-  stopMarkdownWatcher()
+  if (!canReusePreparedCloudQueue) {
+    stopMarkdownWatcher()
+  }
 
   // Обработчик регистрируется до первых сканов: они уже могут ставить
   // облачные плейсхолдеры в очередь докачки. Докачанный файл проходит через
@@ -479,6 +512,15 @@ function initializeMarkdownWatcher(vaultRootPath: string): void {
   // iCloud не порождает (mtime/size не меняются при докачке контента).
   configureCloudDownloads({
     onDownloaded: (absolutePath) => {
+      const assetName = getNotesAssetNameFromAbsolutePath(
+        notesPaths,
+        absolutePath,
+      )
+      if (assetName) {
+        broadcastNotesAssetReady(assetName)
+        return
+      }
+
       const relativeWatchPath = normalizeRelativeWatchPath(
         vaultRootPath,
         absolutePath,
@@ -549,11 +591,14 @@ function initializeMarkdownWatcher(vaultRootPath: string): void {
           )
         })
         .on('unlink', (changedPath: string) => {
-          scheduleStateSync(
+          const relativePath = normalizeRelativeWatchPath(
             vaultRootPath,
-            paths,
-            normalizeRelativeWatchPath(vaultRootPath, changedPath),
+            changedPath,
           )
+          if (isManagedNotesAssetsPath(relativePath)) {
+            return
+          }
+          scheduleStateSync(vaultRootPath, paths, relativePath)
         })
         .on('addDir', (changedPath: string) => {
           scheduleStateSync(
@@ -564,12 +609,14 @@ function initializeMarkdownWatcher(vaultRootPath: string): void {
           )
         })
         .on('unlinkDir', (changedPath: string) => {
-          scheduleStateSync(
+          const relativePath = normalizeRelativeWatchPath(
             vaultRootPath,
-            paths,
-            normalizeRelativeWatchPath(vaultRootPath, changedPath),
-            true,
+            changedPath,
           )
+          if (isManagedNotesAssetsPath(relativePath)) {
+            return
+          }
+          scheduleStateSync(vaultRootPath, paths, relativePath, true)
         })
         .on('error', (error: unknown) => {
           log('storage:markdown:watcher-error', error)
@@ -656,4 +703,34 @@ function tryStartMarkdownWatcher(vaultRootPath: string): boolean {
 
 export function startMarkdownWatcher(): void {
   tryStartMarkdownWatcher(getVaultPath())
+}
+
+export function prepareMarkdownWatcher(): void {
+  if (
+    markdownWatcher
+    || watchedVaultPath
+    || preparedCloudVaultPath
+    || watcherStartToken !== 0
+  ) {
+    return
+  }
+
+  const vaultRootPath = getVaultPath()
+  const notesPaths = getNotesPaths(vaultRootPath)
+
+  configureCloudDownloads({
+    onDownloaded: (absolutePath) => {
+      const assetName = getNotesAssetNameFromAbsolutePath(
+        notesPaths,
+        absolutePath,
+      )
+      if (assetName) {
+        broadcastNotesAssetReady(assetName)
+      }
+    },
+    onQueueActivity: () => {},
+  })
+
+  preparedCloudVaultPath = vaultRootPath
+  preparedWatcherStartToken = watcherStartToken
 }

--- a/src/main/storage/providers/markdown/watcherPaths.ts
+++ b/src/main/storage/providers/markdown/watcherPaths.ts
@@ -14,6 +14,8 @@ import { toPosixPath } from './runtime/shared/path'
 
 export const NOTES_SPACE_WATCH_PREFIX = NOTES_SPACE_ID.toLowerCase()
 export const CODE_SPACE_WATCH_PREFIX = CODE_SPACE_ID.toLowerCase()
+const MANAGED_NOTES_ASSETS_WATCH_ROOT
+  = `${NOTES_SPACE_WATCH_PREFIX}/${META_DIR_NAME}/assets`.toLowerCase()
 
 export function normalizeRelativeWatchPath(
   watchRootPath: string,
@@ -91,6 +93,31 @@ export function shouldIgnoreWatchPath(
 
 export function isNotesWatchPath(relativePath: string | null): boolean {
   return getWatchPathSpaceId(relativePath) === NOTES_SPACE_ID
+}
+
+export function isManagedNotesAssetsPath(relativePath: string | null): boolean {
+  if (!relativePath) {
+    return false
+  }
+
+  const normalizedRelativePath = relativePath.toLowerCase()
+  return (
+    normalizedRelativePath === MANAGED_NOTES_ASSETS_WATCH_ROOT
+    || normalizedRelativePath.startsWith(`${MANAGED_NOTES_ASSETS_WATCH_ROOT}/`)
+  )
+}
+
+export function getManagedNotesAssetName(
+  relativePath: string | null,
+): string | null {
+  if (!isManagedNotesAssetsPath(relativePath) || !relativePath) {
+    return null
+  }
+
+  const fileName = relativePath.slice(
+    MANAGED_NOTES_ASSETS_WATCH_ROOT.length + 1,
+  )
+  return fileName && !fileName.includes('/') ? fileName : null
 }
 
 export function isCodeWatchPath(relativePath: string | null): boolean {

--- a/src/main/types/ipc.ts
+++ b/src/main/types/ipc.ts
@@ -69,6 +69,7 @@ type SystemAction =
   | 'cloud-download-progress'
   | 'migration-complete'
   | 'migration-error'
+  | 'notes-asset-ready'
   | 'error'
 type PrettierAction = 'format'
 type FsAction = 'assets' | 'import-markdown-folder' | 'notes-asset'

--- a/src/renderer/components/notes/cm-extensions/imageInsert.ts
+++ b/src/renderer/components/notes/cm-extensions/imageInsert.ts
@@ -1,20 +1,19 @@
 import { ipc } from '@/electron'
 import { EditorView } from '@codemirror/view'
 
-function getImageExtension(file: File): string {
-  const ext = file.name.includes('.') ? `.${file.name.split('.').pop()}` : ''
-  if (ext)
+function getImageExtension(file: File): string | null {
+  const ext = file.name.includes('.')
+    ? `.${file.name.split('.').pop()?.toLowerCase()}`
+    : ''
+  if (ext === '.png' || ext === '.jpg' || ext === '.jpeg') {
     return ext
+  }
 
   const mimeToExt: Record<string, string> = {
     'image/png': '.png',
     'image/jpeg': '.jpg',
-    'image/gif': '.gif',
-    'image/webp': '.webp',
-    'image/svg+xml': '.svg',
-    'image/bmp': '.bmp',
   }
-  return mimeToExt[file.type] || '.png'
+  return mimeToExt[file.type] ?? null
 }
 
 async function insertImage(view: EditorView, file: File, pos: number) {
@@ -25,9 +24,14 @@ async function insertImage(view: EditorView, file: File, pos: number) {
 
   try {
     const arrayBuffer = await file.arrayBuffer()
-    const buffer = Array.from(new Uint8Array(arrayBuffer))
     const ext = getImageExtension(file)
-    const url: string = await ipc.invoke('fs:notes-asset', { buffer, ext })
+    if (!ext) {
+      throw new TypeError('Unsupported Notes image type')
+    }
+    const url: string = await ipc.invoke('fs:notes-asset', {
+      buffer: arrayBuffer,
+      ext,
+    })
     const alt = file.name.replace(/\.[^.]+$/, '') || 'image'
     const markdown = `![${alt}](${url})`
 
@@ -47,7 +51,7 @@ function getImageFile(dataTransfer: DataTransfer | null): File | null {
   if (!dataTransfer)
     return null
   for (const file of Array.from(dataTransfer.files)) {
-    if (file.type.startsWith('image/'))
+    if (getImageExtension(file))
       return file
   }
   return null

--- a/src/renderer/components/preferences/Storage.vue
+++ b/src/renderer/components/preferences/Storage.vue
@@ -29,6 +29,10 @@ import { i18n, ipc, store } from '@/electron'
 import { AlertTriangle, Check, LoaderCircle } from 'lucide-vue-next'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '~/renderer/services/api'
+import {
+  formatVaultDoctorWarning,
+  getVaultDoctorWarningKey,
+} from './vaultDoctorWarnings'
 
 interface DirectoryStateResponse {
   exists: boolean
@@ -117,6 +121,15 @@ const {
   apply: applyVault,
   reset: resetVaultDoctor,
 } = useVaultDoctor()
+
+const formattedVaultDoctorWarnings = computed(() =>
+  vaultDoctorWarningPreview.value.map(warning => ({
+    ...formatVaultDoctorWarning(warning, (key, options) =>
+      i18n.t(key, options)),
+    key: getVaultDoctorWarningKey(warning),
+    warning,
+  })),
+)
 
 function showLoadingCounts() {
   loadingCountsTimer = setTimeout(() => {
@@ -923,14 +936,31 @@ onMounted(() => {
                 <UiText variant="sm">
                   {{ i18n.t("preferences:storage.vaultDoctor.warnings") }}
                 </UiText>
-                <UiText
-                  v-for="warning in vaultDoctorWarningPreview"
-                  :key="`${warning.space}:${warning.path}:${warning.code}`"
-                  variant="caption"
-                  class="block font-mono break-all"
+                <div
+                  v-for="item in formattedVaultDoctorWarnings"
+                  :key="item.key"
+                  class="space-y-0.5"
                 >
-                  {{ warning.code }} · {{ warning.path }}
-                </UiText>
+                  <UiText
+                    variant="caption"
+                    class="block"
+                  >
+                    {{ item.message }}
+                  </UiText>
+                  <UiText
+                    variant="caption"
+                    class="text-muted-foreground block font-mono break-all"
+                  >
+                    {{ item.warning.path }}
+                  </UiText>
+                  <UiText
+                    v-if="item.recommendation"
+                    variant="caption"
+                    class="text-muted-foreground block"
+                  >
+                    {{ item.recommendation }}
+                  </UiText>
+                </div>
                 <UiText
                   v-if="vaultDoctorHiddenWarningCount > 0"
                   variant="caption"

--- a/src/renderer/components/preferences/__tests__/vaultDoctorWarnings.test.ts
+++ b/src/renderer/components/preferences/__tests__/vaultDoctorWarnings.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  formatVaultDoctorWarning,
+  getVaultDoctorWarningKey,
+} from '../vaultDoctorWarnings'
+
+describe('formatVaultDoctorWarning', () => {
+  it.each([
+    'NOTES_LEGACY_ASSET',
+    'NOTES_ASSET_MIGRATION_PENDING',
+    'NOTES_ASSET_DESTINATION_CONFLICT',
+    'NOTES_ASSET_MISSING',
+  ])('formats %s through localized message and recommendation keys', (code) => {
+    const translate = vi.fn((key: string) => key)
+
+    expect(
+      formatVaultDoctorWarning(
+        {
+          code,
+          details: { assetName: 'abcdefghijklmnop.png' },
+        },
+        translate,
+      ),
+    ).toEqual({
+      message: `preferences:storage.vaultDoctor.assetWarnings.${code}.message`,
+      recommendation: `preferences:storage.vaultDoctor.assetWarnings.${code}.recommendation`,
+    })
+    expect(translate).toHaveBeenCalledWith(expect.any(String), {
+      assetName: 'abcdefghijklmnop.png',
+    })
+  })
+
+  it('falls back to the raw code for other warnings', () => {
+    const translate = vi.fn()
+
+    expect(
+      formatVaultDoctorWarning({ code: 'DANGLING_FOLDER_ID' }, translate),
+    ).toEqual({
+      message: 'DANGLING_FOLDER_ID',
+      recommendation: null,
+    })
+    expect(translate).not.toHaveBeenCalled()
+  })
+
+  it('creates distinct keys for same-code assets in one note', () => {
+    const warning = {
+      code: 'NOTES_LEGACY_ASSET',
+      path: 'Assets.md',
+      space: 'notes',
+    }
+
+    expect(
+      getVaultDoctorWarningKey({
+        ...warning,
+        details: { assetName: 'abcdefghijklmnop.png' },
+      }),
+    ).not.toBe(
+      getVaultDoctorWarningKey({
+        ...warning,
+        details: { assetName: 'ponmlkjihgfedcba.jpg' },
+      }),
+    )
+  })
+})

--- a/src/renderer/components/preferences/vaultDoctorWarnings.ts
+++ b/src/renderer/components/preferences/vaultDoctorWarnings.ts
@@ -1,0 +1,56 @@
+interface VaultDoctorWarningLike {
+  code: string
+  details?: object
+}
+
+interface VaultDoctorWarningKeyInput extends VaultDoctorWarningLike {
+  path: string
+  space: string
+}
+
+interface FormattedVaultDoctorWarning {
+  message: string
+  recommendation: string | null
+}
+
+type Translate = (key: string, options?: Record<string, string>) => string
+
+const NOTES_ASSET_WARNING_CODES = new Set([
+  'NOTES_LEGACY_ASSET',
+  'NOTES_ASSET_MIGRATION_PENDING',
+  'NOTES_ASSET_DESTINATION_CONFLICT',
+  'NOTES_ASSET_MISSING',
+])
+
+function getAssetName(details?: object): string {
+  const value = (details as { assetName?: unknown } | undefined)?.assetName
+  return typeof value === 'string' ? value : ''
+}
+
+export function getVaultDoctorWarningKey(
+  warning: VaultDoctorWarningKeyInput,
+): string {
+  return [
+    warning.space,
+    warning.path,
+    warning.code,
+    getAssetName(warning.details),
+  ].join(':')
+}
+
+export function formatVaultDoctorWarning(
+  warning: VaultDoctorWarningLike,
+  translate: Translate,
+): FormattedVaultDoctorWarning {
+  if (!NOTES_ASSET_WARNING_CODES.has(warning.code)) {
+    return { message: warning.code, recommendation: null }
+  }
+
+  const key = `preferences:storage.vaultDoctor.assetWarnings.${warning.code}`
+  const options = { assetName: getAssetName(warning.details) }
+
+  return {
+    message: translate(`${key}.message`, options),
+    recommendation: translate(`${key}.recommendation`, options),
+  }
+}

--- a/src/renderer/ipc/listeners/system.ts
+++ b/src/renderer/ipc/listeners/system.ts
@@ -24,6 +24,7 @@ import {
 import { i18n, ipc } from '@/electron'
 import { router, RouterName } from '@/router'
 import { getActiveSpaceId } from '@/spaceDefinitions'
+import { retryNotesAssetImages } from '@/utils/notesAssetHydration'
 import { repository } from '../../../../package.json'
 import { handleDeepLink } from './deepLinks'
 
@@ -235,6 +236,12 @@ export function registerSystemListeners() {
 
   ipc.on('system:storage-synced', () => {
     scheduleStorageSyncRefresh()
+  })
+
+  ipc.on('system:notes-asset-ready', (_, fileName: unknown) => {
+    if (typeof fileName === 'string') {
+      retryNotesAssetImages(document, fileName)
+    }
   })
 
   ipc.on(

--- a/src/renderer/utils/__tests__/notesAssetHydration.test.ts
+++ b/src/renderer/utils/__tests__/notesAssetHydration.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+import { retryNotesAssetImages } from '../notesAssetHydration'
+
+function createImage(source: string) {
+  let currentSource = source
+
+  return {
+    getAttribute: vi.fn(() => currentSource),
+    setAttribute: vi.fn((name: string, value: string) => {
+      if (name === 'src') {
+        currentSource = value
+      }
+    }),
+  }
+}
+
+describe('retryNotesAssetImages', () => {
+  it('cache-busts only images with the matching logical asset name', () => {
+    const matching = createImage(
+      'masscode://notes-asset/abcdefghijklmnop.png?hydrated=old',
+    )
+    const other = createImage('masscode://notes-asset/ponmlkjihgfedcba.png')
+    const root = {
+      querySelectorAll: vi.fn(() => [matching, other]),
+    } as unknown as ParentNode
+
+    retryNotesAssetImages(root, 'abcdefghijklmnop.png', 42)
+
+    expect(matching.setAttribute).toHaveBeenCalledWith(
+      'src',
+      'masscode://notes-asset/abcdefghijklmnop.png?hydrated=42',
+    )
+    expect(other.setAttribute).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/utils/index.ts
+++ b/src/renderer/utils/index.ts
@@ -42,4 +42,5 @@ export function getContiguousSelection(
 }
 
 export * from './entryNameValidationMessage'
+export * from './notesAssetHydration'
 export * from './saveErrors'

--- a/src/renderer/utils/notesAssetHydration.ts
+++ b/src/renderer/utils/notesAssetHydration.ts
@@ -1,0 +1,34 @@
+const NOTES_ASSET_HOST = 'notes-asset'
+
+export function retryNotesAssetImages(
+  root: ParentNode,
+  fileName: string,
+  cacheKey: number = Date.now(),
+): void {
+  const images = root.querySelectorAll<HTMLImageElement>(
+    'img[src^="masscode://notes-asset/"]',
+  )
+
+  for (const image of Array.from(images)) {
+    const source = image.getAttribute('src')
+    if (!source) {
+      continue
+    }
+
+    try {
+      const url = new URL(source)
+      const sourceFileName = decodeURIComponent(
+        url.pathname.replace(/^\//, ''),
+      )
+      if (url.hostname !== NOTES_ASSET_HOST || sourceFileName !== fileName) {
+        continue
+      }
+
+      url.searchParams.set('hydrated', String(cacheKey))
+      image.setAttribute('src', url.toString())
+    }
+    catch {
+      // Некорректный src не должен мешать обновлению остальных изображений.
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- store new Notes images in notes/.masscode/assets with safe dual-read compatibility
- migrate referenced legacy assets automatically with hash verification and cloud hydration retries
- add read-only Vault Doctor warnings, localized UI, move-vault coverage, and updated documentation

## Validation
- 168 scoped tests
- main TypeScript typecheck
- locale sync
- VitePress documentation build