### PR TITLE
feat(notes): add note duplication

### DIFF
--- a/src/renderer/components/command-palette/CommandPalette.vue
+++ b/src/renderer/components/command-palette/CommandPalette.vue
@@ -585,8 +585,10 @@ function hasItemLinkAction(result: CommandPaletteResult) {
 function hasDuplicateAction(result: CommandPaletteResult) {
   return (
     result.type === 'snippet'
+    || result.type === 'note'
     || result.type === 'http-request'
     || isRecentTarget(result, 'snippet')
+    || isRecentTarget(result, 'note')
     || isRecentTarget(result, 'http-request')
   )
 }
@@ -755,6 +757,13 @@ async function getHttpRequest(result: CommandPaletteResult) {
 async function duplicateItem(result: CommandPaletteResult) {
   if (result.type === 'snippet' || isRecentTarget(result, 'snippet')) {
     await duplicateSnippet(result)
+  }
+  else if (result.type === 'note' || isRecentTarget(result, 'note')) {
+    const payload = getItemPayload(result)
+
+    if (payload) {
+      await notesData.duplicateNote(Number(payload.targetId))
+    }
   }
   else if (
     result.type === 'http-request'

--- a/src/renderer/components/notes/NotesListItemContextMenu.vue
+++ b/src/renderer/components/notes/NotesListItemContextMenu.vue
@@ -44,7 +44,7 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const { notesState } = useNotesApp()
+const { focusNoteNameInput, notesState } = useNotesApp()
 
 const {
   selectFirstNote,
@@ -53,6 +53,8 @@ const {
   updateNoteProperties,
   updateNotes,
   deleteSelectedNotes,
+  duplicateNote,
+  selectNote,
 } = useNotes()
 
 const { copy } = useClipboard()
@@ -100,6 +102,15 @@ async function onAddFavorites() {
 
 async function onDelete() {
   await deleteSelectedNotes(props.note)
+}
+
+async function onDuplicate() {
+  const id = await duplicateNote(props.note.id)
+
+  if (id) {
+    selectNote(id)
+    await focusNoteNameInput()
+  }
 }
 
 async function onRestore() {
@@ -204,6 +215,13 @@ async function onConvertToNote() {
       {{ i18n.t("action.copy.noteLink") }}
     </ContextMenu.ContextMenuItem>
     <ContextMenu.ContextMenuSeparator />
+    <ContextMenu.ContextMenuItem
+      v-if="!isTrashLibrarySelected"
+      :disabled="isCloudPending || selectedNoteIds.length > 1"
+      @click="onDuplicate"
+    >
+      {{ i18n.t("action.duplicate") }}
+    </ContextMenu.ContextMenuItem>
     <ContextMenu.ContextMenuItem
       :disabled="isCloudPending"
       @click="onDelete"

--- a/src/renderer/composables/spaces/notes/__tests__/useNotes.test.ts
+++ b/src/renderer/composables/spaces/notes/__tests__/useNotes.test.ts
@@ -48,6 +48,9 @@ async function setup(options: SetupOptions = {}) {
     data: { id: Number(id) },
   }))
   const postNotes = vi.fn(async () => ({ data: { id: 7 } }))
+  const patchNotesById = vi.fn(async () => undefined)
+  const patchNotesByIdContent = vi.fn(async () => undefined)
+  const postNotesByIdTagsByTagId = vi.fn(async () => undefined)
   const sonner = vi.fn()
 
   vi.doMock('@/composables/useContentSort', () => ({
@@ -97,11 +100,11 @@ async function setup(options: SetupOptions = {}) {
         deleteNotesByIdTagsByTagId: vi.fn(),
         getNotes,
         getNotesById,
-        patchNotesById: vi.fn(),
-        patchNotesByIdContent: vi.fn(),
+        patchNotesById,
+        patchNotesByIdContent,
         patchNotesByIdProperties,
         postNotes,
-        postNotesByIdTagsByTagId: vi.fn(),
+        postNotesByIdTagsByTagId,
         postNotesTasksCleanup,
       },
     },
@@ -135,8 +138,11 @@ async function setup(options: SetupOptions = {}) {
     getNotes,
     markPersistedStorageMutation,
     notesState,
+    patchNotesById,
+    patchNotesByIdContent,
     patchNotesByIdProperties,
     postNotes,
+    postNotesByIdTagsByTagId,
     postNotesTasksCleanup,
     searchQuery,
     selectedNoteIds,
@@ -221,6 +227,108 @@ describe('useNotes', () => {
     })
     expect(context.notesState.libraryFilter).toBe('all')
     expect(context.notesState.noteId).toBe(7)
+  })
+
+  it('duplicates note fields, content and tags with a unique sibling name', async () => {
+    const context = await setup({
+      folderId: 4,
+      libraryFilter: 'all',
+      nextNotes: [
+        { id: 1, folder: { id: 4 }, name: 'Plan' },
+        { id: 2, folder: { id: 4 }, name: 'Plan - copy' },
+        { id: 3, folder: { id: 4 }, name: 'Plan - copy 2' },
+      ],
+    })
+    const apiModule = await import('~/renderer/services/api')
+    vi.mocked(apiModule.api.notes.getNotesById).mockResolvedValueOnce({
+      data: {
+        content: '# Plan',
+        description: 'Release plan',
+        folder: { id: 4, name: 'Projects' },
+        id: 1,
+        name: 'Plan',
+        properties: { priority: 'high', type: 'task' },
+        tags: [
+          { id: 8, name: 'work' },
+          { id: 9, name: 'release' },
+        ],
+      },
+    } as never)
+
+    const id = await context.useNotes().duplicateNote(1)
+
+    expect(id).toBe(7)
+    expect(context.postNotes).toHaveBeenCalledWith({
+      folderId: 4,
+      name: 'Plan - copy 3',
+      properties: { priority: 'high', type: 'task' },
+    })
+    expect(context.patchNotesById).toHaveBeenCalledWith('7', {
+      description: 'Release plan',
+    })
+    expect(context.patchNotesByIdContent).toHaveBeenCalledWith('7', {
+      content: '# Plan',
+    })
+    expect(context.postNotesByIdTagsByTagId.mock.calls).toEqual([
+      ['7', '8'],
+      ['7', '9'],
+    ])
+    expect(context.markPersistedStorageMutation).toHaveBeenCalledOnce()
+    expect(context.getNotes).toHaveBeenCalledTimes(2)
+    expect(context.getNotes).toHaveBeenLastCalledWith({ folderId: 4 })
+  })
+
+  it.each([
+    ['cloud-pending', { pendingCloudDownload: true }, true],
+    ['deleted', { isDeleted: 1 }, false],
+  ])('does not duplicate a %s note', async (_, sourceState, expectsWarning) => {
+    const context = await setup({ libraryFilter: 'all' })
+    const apiModule = await import('~/renderer/services/api')
+    vi.mocked(apiModule.api.notes.getNotesById).mockResolvedValueOnce({
+      data: {
+        content: '# Plan',
+        description: null,
+        folder: null,
+        id: 1,
+        isDeleted: 0,
+        name: 'Plan',
+        properties: {},
+        tags: [],
+        ...sourceState,
+      },
+    } as never)
+
+    const id = await context.useNotes().duplicateNote(1)
+
+    expect(id).toBeUndefined()
+    expect(context.postNotes).not.toHaveBeenCalled()
+    expect(context.markPersistedStorageMutation).not.toHaveBeenCalled()
+    expect(context.sonner).toHaveBeenCalledTimes(expectsWarning ? 1 : 0)
+  })
+
+  it('switches Favorites to All before refreshing a duplicated note', async () => {
+    const context = await setup({
+      libraryFilter: 'favorites',
+      nextNotes: [{ id: 1, folder: null, name: 'Plan' }],
+    })
+    const apiModule = await import('~/renderer/services/api')
+    vi.mocked(apiModule.api.notes.getNotesById).mockResolvedValueOnce({
+      data: {
+        content: '',
+        description: null,
+        folder: null,
+        id: 1,
+        isDeleted: 0,
+        name: 'Plan',
+        properties: {},
+        tags: [],
+      },
+    } as never)
+
+    await context.useNotes().duplicateNote(1)
+
+    expect(context.notesState.libraryFilter).toBe('all')
+    expect(context.getNotes).toHaveBeenLastCalledWith({ isDeleted: 0 })
   })
 
   it('combines search with the selected tag context', async () => {

--- a/src/renderer/composables/spaces/notes/useNotes.ts
+++ b/src/renderer/composables/spaces/notes/useNotes.ts
@@ -508,6 +508,63 @@ async function createNoteWithPayloadAndSelect(payload?: CreateNotePayload) {
   await focusNoteNameInput()
 }
 
+async function duplicateNote(noteId: number) {
+  try {
+    // Список не содержит контент заметки — источник копии загружается по id.
+    const { data: sourceData } = await api.notes.getNotesById(String(noteId))
+    const source = sourceData as NoteFullRecord
+
+    if (source.pendingCloudDownload) {
+      useSonner().sonner({
+        id: 'cloud-file-not-ready',
+        message: i18n.t('messages:warning.cloudFileNotReady'),
+        type: 'warning',
+      })
+      return
+    }
+
+    if (source.isDeleted) {
+      return
+    }
+
+    const folderId = source.folder?.id ?? null
+    const siblingNames = await getNoteNamesForCreate(folderId)
+    const copyBaseName = `${source.name} - copy`
+    const name = siblingNames.some(
+      sibling => sibling.trim().toLowerCase() === copyBaseName.toLowerCase(),
+    )
+      ? getNextIndexedName(copyBaseName, siblingNames)
+      : copyBaseName
+
+    markPersistedStorageMutation()
+    const { data } = await api.notes.postNotes({
+      folderId,
+      name,
+      properties: source.properties,
+    })
+    const id = Number(data.id)
+
+    await api.notes.patchNotesById(String(id), {
+      description: source.description,
+    })
+    await api.notes.patchNotesByIdContent(String(id), {
+      content: source.content,
+    })
+
+    for (const tag of source.tags) {
+      await api.notes.postNotesByIdTagsByTagId(String(id), String(tag.id))
+    }
+
+    ensureCreateResultCanBeListed({ properties: source.properties })
+    await getNotes(queryByLibraryOrFolderOrSearch.value)
+
+    return id
+  }
+  catch (error) {
+    console.error(error)
+  }
+}
+
 // Поля, влияющие на состав текущего списка: после их изменения нужен refetch.
 function isNoteListMembershipAffecting(data: NotesUpdate) {
   return (
@@ -866,6 +923,7 @@ export function useNotes() {
     deleteNotes,
     deleteSelectedNotes,
     deleteTagFromNote,
+    duplicateNote,
     emptyTrash,
     getNotes,
     hasBusyNoteContentUpdates,


### PR DESCRIPTION
## Summary
- add note duplication to the context menu and command palette
- preserve note content, metadata, properties, folder, and tags
- generate unique copy names and protect cloud-pending and deleted notes

## Testing
- pnpm test src/renderer/composables/spaces/notes/__tests__/useNotes.test.ts
- scoped ESLint
- git diff --check