### PR TITLE
fix(storage): prevent false cloud placeholder detection on Windows

### DIFF
--- a/src/main/storage/providers/markdown/runtime/__tests__/cloudPlaceholders.test.ts
+++ b/src/main/storage/providers/markdown/runtime/__tests__/cloudPlaceholders.test.ts
@@ -4,8 +4,14 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { enqueueCloudDownload } from '../../cloudDownloads'
+import { createFoldersStorage } from '../../storages/folders'
+import { createSnippetsStorage } from '../../storages/snippets'
 import { runtimeRef } from '../cache'
-import { setDatalessProbeForTests } from '../shared/cloudFiles'
+import { getPaths } from '../paths'
+import {
+  getFileAvailability,
+  setDatalessProbeForTests,
+} from '../shared/cloudFiles'
 import { assertNoUnknownDomainFiles } from '../shared/foldersStorage'
 import { ensureSnippetContentLoaded, writeSnippetToFile } from '../snippets'
 import { saveState } from '../state'
@@ -25,10 +31,13 @@ vi.mock('electron', () => ({
   },
 }))
 
+const storageMock = vi.hoisted(() => ({ vaultPath: '' }))
+
 vi.mock('../../../../../store', () => ({
   store: {
     preferences: {
-      get: () => undefined,
+      get: (key: string) =>
+        key === 'storage.vaultPath' ? storageMock.vaultPath : undefined,
     },
   },
 }))
@@ -54,6 +63,16 @@ function createPaths(): Paths {
     trashDirPath: path.join(metaDirPath, 'trash'),
     vaultPath,
   }
+}
+
+function createStoragePaths(): Paths {
+  const vaultPath = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'cloud-placeholder-storage-'),
+  )
+  tempDirs.push(vaultPath)
+  storageMock.vaultPath = vaultPath
+
+  return getPaths(vaultPath)
 }
 
 function writeSnippetFixture(
@@ -110,6 +129,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  storageMock.vaultPath = ''
   setDatalessProbeForTests(null)
   resetRuntimeCache()
   vi.mocked(enqueueCloudDownload).mockClear()
@@ -120,6 +140,176 @@ afterEach(() => {
 })
 
 describe('cloud placeholder handling in code runtime', () => {
+  it('allows immediate content write and rename of an app-written file', () => {
+    const paths = createStoragePaths()
+    const targetPath = path.join(paths.vaultPath, '.masscode/inbox/Renamed.md')
+    const statSync = fs.statSync.bind(fs)
+    const statSpy = vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+      const stats = statSync(filePath)
+
+      if (
+        typeof filePath === 'string'
+        && filePath.endsWith('.md')
+        && stats.size > 0
+      ) {
+        return Object.assign(stats, { blocks: 0 })
+      }
+
+      return stats
+    })
+
+    try {
+      const storage = createSnippetsStorage()
+      const { id } = storage.createSnippet({ name: 'Resident' })
+      expect(() =>
+        storage.createSnippetContent(id, {
+          label: 'Fragment 1',
+          language: 'plain_text',
+          value: 'body',
+        }),
+      ).not.toThrow()
+
+      resetRuntimeCache()
+      syncRuntimeWithDisk(paths)
+      resetRuntimeCache()
+      const lazyCache = syncRuntimeWithDisk(paths)
+      const lazySnippet = lazyCache.snippets.find(
+        snippet => snippet.id === id,
+      )
+      expect(lazySnippet?.contents[0]?.value).toBeNull()
+
+      expect(() =>
+        storage.updateSnippet(id, { name: 'Renamed' }),
+      ).not.toThrow()
+
+      expect(fs.readFileSync(targetPath, 'utf8')).toContain('body')
+    }
+    finally {
+      statSpy.mockRestore()
+    }
+  })
+
+  it('keeps local folder contents available without rewriting placeholders', () => {
+    const paths = createStoragePaths()
+    const statSync = fs.statSync.bind(fs)
+    const statSpy = vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+      const stats = statSync(filePath)
+
+      if (
+        typeof filePath === 'string'
+        && filePath.endsWith('.md')
+        && stats.size > 0
+      ) {
+        return Object.assign(stats, { blocks: 0 })
+      }
+
+      return stats
+    })
+    const foldersStorage = createFoldersStorage()
+    const storage = createSnippetsStorage()
+    const folder = foldersStorage.createFolder({ name: 'Folder' })
+    let localId = 0
+    let placeholderId = 0
+    let placeholderSourcePath = ''
+
+    try {
+      localId = storage.createSnippet({
+        folderId: folder.id,
+        name: 'Resident',
+      }).id
+      storage.createSnippetContent(localId, {
+        label: 'Fragment 1',
+        language: 'plain_text',
+        value: 'local body',
+      })
+
+      placeholderId = storage.createSnippet({
+        folderId: folder.id,
+        name: 'Pending',
+      }).id
+      storage.createSnippetContent(placeholderId, {
+        label: 'Fragment 1',
+        language: 'plain_text',
+        value: 'remote body',
+      })
+      const placeholder = runtimeRef.cache!.snippets.find(
+        item => item.id === placeholderId,
+      )!
+      placeholderSourcePath = path.join(paths.vaultPath, placeholder.filePath)
+
+      makeSparsePlaceholder(placeholderSourcePath)
+      if (!hasPlaceholderSignature(placeholderSourcePath)) {
+        return
+      }
+
+      expect(foldersStorage.deleteFolder(folder.id).deleted).toBe(true)
+
+      const local = runtimeRef.cache!.snippets.find(
+        item => item.id === localId,
+      )!
+      const pending = runtimeRef.cache!.snippets.find(
+        item => item.id === placeholderId,
+      )!
+      const localTargetPath = path.join(paths.vaultPath, local.filePath)
+      const placeholderTargetPath = path.join(
+        paths.vaultPath,
+        pending.filePath,
+      )
+
+      expect(getFileAvailability(localTargetPath).isCloudPlaceholder).toBe(
+        false,
+      )
+      expect(hasPlaceholderSignature(placeholderTargetPath)).toBe(true)
+      expect(fs.statSync(placeholderTargetPath).size).toBe(4096)
+    }
+    finally {
+      statSpy.mockRestore()
+    }
+  })
+
+  it('keeps a committed write successful when its follow-up stat fails', () => {
+    const paths = createPaths()
+    const snippetPath = path.join(paths.vaultPath, '.masscode/inbox/saved.md')
+    const statSync = fs.statSync.bind(fs)
+    const statSpy = vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+      if (filePath === snippetPath && fs.existsSync(snippetPath)) {
+        throw new Error('post-write stat failed')
+      }
+
+      return statSync(filePath)
+    })
+
+    try {
+      expect(() =>
+        writeSnippetToFile(paths, {
+          contents: [
+            {
+              id: 1,
+              label: 'Fragment 1',
+              language: 'plain_text',
+              value: 'saved body',
+            },
+          ],
+          createdAt: 1700000000000,
+          description: null,
+          filePath: '.masscode/inbox/saved.md',
+          folderId: null,
+          id: 2,
+          isDeleted: 0,
+          isFavorites: 0,
+          name: 'Saved',
+          tags: [],
+          updatedAt: 1700000000000,
+        }),
+      ).not.toThrow()
+    }
+    finally {
+      statSpy.mockRestore()
+    }
+
+    expect(fs.readFileSync(snippetPath, 'utf8')).toContain('saved body')
+  })
+
   it('keeps known placeholder snippets in the list without reading them', () => {
     const paths = createPaths()
     const localPath = writeSnippetFixture(

--- a/src/main/storage/providers/markdown/runtime/shared/__tests__/cloudFiles.test.ts
+++ b/src/main/storage/providers/markdown/runtime/shared/__tests__/cloudFiles.test.ts
@@ -1,7 +1,7 @@
 import os from 'node:os'
 import path from 'node:path'
 import fs from 'fs-extra'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   getFileAvailability,
   isCloudPlaceholderStats,
@@ -114,8 +114,19 @@ describe('getFileAvailability', () => {
     expect(getFileAvailability(filePath).isCloudPlaceholder).toBe(true)
 
     // Ридер успешно прочитал файл: с этого момента он считается локальным,
-    // пока не изменится (size + mtime).
+    // пока не изменится (size + mtime + ctime).
     markFileReadableDespiteZeroBlocks(filePath, stats)
     expect(getFileAvailability(filePath).isCloudPlaceholder).toBe(false)
+
+    const statSpy = vi
+      .spyOn(fs, 'statSync')
+      .mockReturnValue(Object.assign(stats, { ctimeMs: stats.ctimeMs + 1 }))
+
+    try {
+      expect(getFileAvailability(filePath).isCloudPlaceholder).toBe(true)
+    }
+    finally {
+      statSpy.mockRestore()
+    }
   })
 })

--- a/src/main/storage/providers/markdown/runtime/shared/cloudFiles.ts
+++ b/src/main/storage/providers/markdown/runtime/shared/cloudFiles.ts
@@ -46,10 +46,10 @@ function hasSimulatedCloudStub(absolutePath: string): boolean {
 // Файлы, у которых сигнатура плейсхолдера (size > 0, blocks === 0) оказалась
 // ложной: их содержимое успешно прочитано (inline-файлы btrfs, resident-файлы
 // NTFS, сетевые шары с нулевым AllocationSize). Ключ — путь, значение —
-// size и mtime на момент проверки: изменение файла сбрасывает исключение.
+// size, mtime и ctime на момент проверки: изменение файла сбрасывает исключение.
 const readableZeroBlockFiles = new Map<
   string,
-  { mtimeMs: number, size: number }
+  { ctimeMs: number, mtimeMs: number, size: number }
 >()
 
 // Кэш точной проверки SF_DATALESS на macOS: spawn стоит миллисекунды, но
@@ -64,9 +64,24 @@ export function markFileReadableDespiteZeroBlocks(
   stats: Stats,
 ): void {
   readableZeroBlockFiles.set(absolutePath, {
+    ctimeMs: stats.ctimeMs,
     mtimeMs: stats.mtimeMs,
     size: stats.size,
   })
+}
+
+export function markAppWrittenFileAsLocal(absolutePath: string): void {
+  try {
+    const stats = fs.statSync(absolutePath)
+
+    if (hasPlaceholderSignature(stats)) {
+      markFileReadableDespiteZeroBlocks(absolutePath, stats)
+    }
+  }
+  catch {
+    // Запись уже завершена: сбой best-effort stat не должен превращать её
+    // в ошибку. Файл просто останется без исключения до успешного чтения.
+  }
 }
 
 export function resetCloudFileExemptions(): void {
@@ -228,6 +243,7 @@ export function getFileAvailability(absolutePath: string): FileAvailability {
 
       if (
         exemption
+        && exemption.ctimeMs === stats.ctimeMs
         && exemption.mtimeMs === stats.mtimeMs
         && exemption.size === stats.size
       ) {

--- a/src/main/storage/providers/markdown/runtime/snippets.ts
+++ b/src/main/storage/providers/markdown/runtime/snippets.ts
@@ -36,7 +36,10 @@ import {
   normalizeDirectoryPath,
 } from './paths'
 import { rememberAppFileChange } from './shared/appChanges'
-import { getFileAvailability } from './shared/cloudFiles'
+import {
+  getFileAvailability,
+  markAppWrittenFileAsLocal,
+} from './shared/cloudFiles'
 import { throwCloudContentUnavailable } from './shared/cloudGuards'
 import {
   getCachedDirectoryEntries,
@@ -532,12 +535,18 @@ export function loadSnippets(
     .filter((snippet): snippet is MarkdownSnippet => !!snippet)
 }
 
+const trustedMovedLocalWrite = Symbol('trusted-moved-local-write')
+
 export function writeSnippetToFile(
   paths: Paths,
   snippet: MarkdownSnippet,
-  options?: { skipIfUnavailable?: boolean },
+  options?: {
+    skipIfUnavailable?: boolean
+    [trustedMovedLocalWrite]?: true
+  },
 ): void {
   const snippetPath = path.join(paths.vaultPath, snippet.filePath)
+  const canWriteMovedLocalFile = options?.[trustedMovedLocalWrite] === true
 
   // Запись в плейсхолдер уничтожила бы ещё не скачанное облачное
   // содержимое, поэтому она запрещена: файл сначала докачивается в фоне.
@@ -545,13 +554,28 @@ export function writeSnippetToFile(
   // правку, которую докачка затем молча перезапишет облачным содержимым.
   // Пропуск допустим только там, где запись — необязательный write-back
   // (scan, move, bulk-очистка тегов), а не сохранение пользовательской правки.
-  const availability = getFileAvailability(snippetPath)
-  if (snippet.pendingCloudDownload || availability.isCloudPlaceholder) {
+  if (snippet.pendingCloudDownload) {
     enqueueCloudDownload(snippetPath)
     if (options?.skipIfUnavailable) {
       return
     }
     throwCloudContentUnavailable()
+  }
+
+  const availability = canWriteMovedLocalFile
+    ? null
+    : getFileAvailability(snippetPath)
+
+  if (availability?.isCloudPlaceholder) {
+    enqueueCloudDownload(snippetPath)
+    if (options?.skipIfUnavailable) {
+      return
+    }
+    throwCloudContentUnavailable()
+  }
+
+  if (canWriteMovedLocalFile) {
+    markAppWrittenFileAsLocal(snippetPath)
   }
 
   // Ленивая запись (тела ещё не дочитаны из индекса): недостающие value
@@ -567,15 +591,19 @@ export function writeSnippetToFile(
 
   fs.ensureDirSync(path.dirname(snippetPath))
 
-  if (availability.exists) {
+  if (canWriteMovedLocalFile || availability?.exists) {
     const currentContent = fs.readFileSync(snippetPath, 'utf8')
     if (currentContent === nextContent) {
+      if (canWriteMovedLocalFile) {
+        markAppWrittenFileAsLocal(snippetPath)
+      }
       return
     }
   }
 
   fs.writeFileSync(snippetPath, nextContent, 'utf8')
   rememberAppFileChange(snippetPath)
+  markAppWrittenFileAsLocal(snippetPath)
 }
 
 function upsertSnippetIndex(
@@ -747,6 +775,7 @@ export function persistSnippet(
     ? path.join(paths.vaultPath, sourcePath)
     : null
   const targetAbsolutePath = path.join(paths.vaultPath, targetPath)
+  let moved = false
 
   if (
     sourceAbsolutePath
@@ -756,6 +785,7 @@ export function persistSnippet(
   ) {
     fs.ensureDirSync(path.dirname(targetAbsolutePath))
     fs.moveSync(sourceAbsolutePath, targetAbsolutePath, { overwrite: false })
+    moved = true
     rememberAppFileChange(sourceAbsolutePath)
     rememberAppFileChange(targetAbsolutePath)
 
@@ -769,7 +799,11 @@ export function persistSnippet(
   snippet.filePath = targetPath
   writeSnippetToFile(paths, snippet, {
     skipIfUnavailable: options?.skipWriteIfUnavailable,
+    ...(moved && options?.sourceFileVerifiedLocal
+      ? { [trustedMovedLocalWrite]: true as const }
+      : {}),
   })
+
   upsertDirectoryEntryInCache(
     path.dirname(targetAbsolutePath),
     path.basename(targetAbsolutePath),

--- a/src/main/storage/providers/markdown/runtime/types.ts
+++ b/src/main/storage/providers/markdown/runtime/types.ts
@@ -207,6 +207,9 @@ export type DirectoryEntriesCache = Map<string, string[]>
 export interface PersistSnippetOptions {
   allowRenameOnConflict?: boolean
   directoryEntriesCache?: Map<string, string[]>
+  // Каллер проверил source до мутации и move: после переноса runtime может
+  // безопасно выполнить одну запись resident/zero-block файла по новому пути.
+  sourceFileVerifiedLocal?: boolean
   // Move-пути (перенос в trash при удалении папки): файл-плейсхолдер уже
   // перемещён, а перезапись frontmatter не обязательна и не должна валить
   // всю операцию.

--- a/src/main/storage/providers/markdown/storages/folders.ts
+++ b/src/main/storage/providers/markdown/storages/folders.ts
@@ -25,6 +25,7 @@ import {
   throwStorageError,
   validateEntryName,
 } from '../runtime'
+import { getFileAvailability } from '../runtime/shared/cloudFiles'
 import {
   applyFolderParentAndOrder,
   assertFolderMoveTargetValid,
@@ -314,6 +315,14 @@ export function createFoldersStorage(): FoldersStorage {
           && removedFolderIds.has(snippet.folderId)
         ) {
           const previousPath = snippet.filePath
+          const sourceAvailability = getFileAvailability(
+            path.join(paths.vaultPath, previousPath),
+          )
+          const sourceFileVerifiedLocal
+            = !snippet.pendingCloudDownload
+              && sourceAvailability.exists
+              && !sourceAvailability.isCloudPlaceholder
+
           snippet.folderId = null
           snippet.isDeleted = 1
           snippet.updatedAt = Date.now()
@@ -321,6 +330,7 @@ export function createFoldersStorage(): FoldersStorage {
             allowRenameOnConflict: true,
             directoryEntriesCache,
             skipWriteIfUnavailable: true,
+            sourceFileVerifiedLocal,
           })
         }
       })

--- a/src/main/storage/providers/markdown/storages/snippets.ts
+++ b/src/main/storage/providers/markdown/storages/snippets.ts
@@ -282,6 +282,8 @@ export function createSnippetsStorage(): SnippetsStorage {
       snippet.updatedAt = Date.now()
       persistSnippet(paths, state, snippet, previousPath, {
         allowRenameOnConflict: movedToTrash || movedBetweenDirectories,
+        // assertEntityFileWritable выше уже проверил source до mutation.
+        sourceFileVerifiedLocal: true,
         // Перенос в trash не требует перезаписи frontmatter (isDeleted
         // выводится из trash-каталога), поэтому недокачанный файл не должен
         // блокировать удаление.

--- a/src/renderer/components/editor/Editor.vue
+++ b/src/renderer/components/editor/Editor.vue
@@ -221,7 +221,17 @@ async function init() {
   ipc.on('main-menu:copy-snippet', onCopySnippetMenu)
 
   watch(selectedSnippetContent, (v) => {
+    const scheduledSnippetId = selectedSnippet.value?.id
+    const scheduledContentId = v?.id
+
     nextTick(() => {
+      if (
+        selectedSnippet.value?.id !== scheduledSnippetId
+        || selectedSnippetContent.value?.id !== scheduledContentId
+      ) {
+        return
+      }
+
       // Полная запись выбранного сниппета ещё загружается — не очищаем
       // редактор промежуточным состоянием (метаданные без value).
       if (selectedSnippet.value && (!v || v.value === undefined)) {
@@ -265,9 +275,17 @@ async function init() {
   })
 
   watch(selectedSnippetContent, (v) => {
+    const scheduledSnippetId = selectedSnippet.value?.id
+    const scheduledContentId = v?.id
+
     nextTick(() => {
-      if (!v)
+      if (
+        !v
+        || selectedSnippet.value?.id !== scheduledSnippetId
+        || selectedSnippetContent.value?.id !== scheduledContentId
+      ) {
         return
+      }
       setLanguage(v.language as Language)
     })
   })


### PR DESCRIPTION
## Summary

- prevents local NTFS resident files from being misclassified as cloud placeholders
- preserves local snippet availability during creation, rename, and folder deletion
- keeps protection for genuinely unavailable cloud files
- prevents stale editor updates after switching snippets

## Tests

- 41 scoped Vitest tests passed
- scoped ESLint passed
- git diff check passed

Closes #877