### PR TITLE
fix(storage): keep app-written state files local

### DIFF
--- a/src/main/storage/providers/markdown/runtime/shared/__tests__/stateWriter.test.ts
+++ b/src/main/storage/providers/markdown/runtime/shared/__tests__/stateWriter.test.ts
@@ -1,0 +1,123 @@
+import type { Stats } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'fs-extra'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  enqueueCloudDownload,
+  prioritizeCloudDownload,
+} from '../../../cloudDownloads'
+import {
+  pendingStateWriteByPath,
+  stateContentCacheByPath,
+  stateFlushTimerByPath,
+} from '../../cache'
+import {
+  resetCloudFileExemptions,
+  setDatalessProbeForTests,
+} from '../cloudFiles'
+import { createStateAdapter } from '../stateAdapter'
+import { scheduleStateFlush } from '../stateWriter'
+
+vi.mock('../../../cloudDownloads', () => ({
+  enqueueCloudDownload: vi.fn(),
+  prioritizeCloudDownload: vi.fn(),
+}))
+
+const tempDirs: string[] = []
+
+function createStatePath(): string {
+  const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'state-writer-'))
+  tempDirs.push(dirPath)
+  return path.join(dirPath, '.masscode', 'state.json')
+}
+
+function mockZeroBlockStateFile(statePath: string): void {
+  const statSync = fs.statSync.bind(fs)
+
+  vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+    const stats = statSync(filePath)
+
+    if (filePath === statePath && stats.size > 0) {
+      return Object.assign(stats, { blocks: 0 }) as Stats
+    }
+
+    return stats
+  })
+}
+
+afterEach(() => {
+  for (const timer of stateFlushTimerByPath.values()) {
+    clearTimeout(timer)
+  }
+
+  pendingStateWriteByPath.clear()
+  stateContentCacheByPath.clear()
+  stateFlushTimerByPath.clear()
+  setDatalessProbeForTests(null)
+  resetCloudFileExemptions()
+  vi.clearAllMocks()
+  vi.restoreAllMocks()
+
+  for (const dirPath of tempDirs.splice(0)) {
+    fs.removeSync(dirPath)
+  }
+})
+
+describe('stateWriter cloud placeholder guard', () => {
+  it('keeps an app-written zero-block state file writable', () => {
+    const statePath = createStatePath()
+    mockZeroBlockStateFile(statePath)
+    setDatalessProbeForTests(() => true)
+
+    scheduleStateFlush(statePath, '{"version":1}\n', { immediate: true })
+    scheduleStateFlush(statePath, '{"version":2}\n', { immediate: true })
+
+    expect(fs.readFileSync(statePath, 'utf8')).toBe('{"version":2}\n')
+    expect(enqueueCloudDownload).not.toHaveBeenCalled()
+    expect(pendingStateWriteByPath.has(statePath)).toBe(false)
+  })
+
+  it('does not overwrite a pre-existing cloud placeholder', () => {
+    const statePath = createStatePath()
+    fs.ensureDirSync(path.dirname(statePath))
+    fs.writeFileSync(statePath, 'cloud state', 'utf8')
+    mockZeroBlockStateFile(statePath)
+    setDatalessProbeForTests(() => true)
+
+    scheduleStateFlush(statePath, 'local state', { immediate: true })
+
+    expect(fs.readFileSync(statePath, 'utf8')).toBe('cloud state')
+    expect(pendingStateWriteByPath.get(statePath)).toBe('local state')
+    expect(stateFlushTimerByPath.has(statePath)).toBe(true)
+    expect(enqueueCloudDownload).toHaveBeenCalledWith(statePath)
+  })
+})
+
+describe('stateAdapter default state', () => {
+  it('reads a just-created zero-block default state immediately', () => {
+    const statePath = createStatePath()
+    mockZeroBlockStateFile(statePath)
+    setDatalessProbeForTests(() => true)
+
+    const defaultState = {
+      folderUi: {},
+      folders: [],
+      version: 1,
+    }
+    const adapter = createStateAdapter<
+      typeof defaultState,
+      typeof defaultState,
+      { statePath: string }
+    >({
+      createDefaultState: () => defaultState,
+      getDirs: paths => [path.dirname(paths.statePath)],
+      minVersion: 1,
+      parseRawState: raw => raw,
+      toPersistedState: state => state,
+    })
+
+    expect(adapter.loadState({ statePath })).toEqual(defaultState)
+    expect(prioritizeCloudDownload).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/storage/providers/markdown/runtime/shared/stateAdapter.ts
+++ b/src/main/storage/providers/markdown/runtime/shared/stateAdapter.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra'
 import { stateContentCacheByPath } from '../cache'
 import { normalizeFlag, normalizeFolderUiState } from '../normalizers'
+import { markAppWrittenFileAsLocal } from './cloudFiles'
 import { readVaultTextFileSync } from './guardedRead'
 import {
   flushPendingStateWriteByPath,
@@ -56,6 +57,7 @@ export function createStateAdapter<
     if (!fs.pathExistsSync(paths.statePath)) {
       const defaultStateContent = `${JSON.stringify(config.createDefaultState(), null, 2)}\n`
       fs.writeFileSync(paths.statePath, defaultStateContent, 'utf8')
+      markAppWrittenFileAsLocal(paths.statePath)
       stateContentCacheByPath.set(paths.statePath, defaultStateContent)
     }
   }

--- a/src/main/storage/providers/markdown/runtime/shared/stateWriter.ts
+++ b/src/main/storage/providers/markdown/runtime/shared/stateWriter.ts
@@ -9,7 +9,7 @@ import {
 } from '../cache'
 import { STATE_WRITE_DEBOUNCE_MS } from '../constants'
 import { rememberAppFileChange } from './appChanges'
-import { getFileAvailability } from './cloudFiles'
+import { getFileAvailability, markAppWrittenFileAsLocal } from './cloudFiles'
 
 const CLOUD_STATE_FLUSH_RETRY_MS = 5_000
 
@@ -63,6 +63,7 @@ function flushPath(statePath: string): void {
     fs.ensureDirSync(path.dirname(statePath))
     fs.writeFileSync(statePath, pendingContent, 'utf8')
     rememberAppFileChange(statePath)
+    markAppWrittenFileAsLocal(statePath)
   }
 
   stateContentCacheByPath.set(statePath, pendingContent)


### PR DESCRIPTION
## Summary

- mark newly created and updated state files as local after successful writes
- preserve hydration protection for existing cloud placeholders
- add focused coverage for local zero-block and placeholder state files