### PR TITLE
fix(storage): preserve pending state during lifecycle resets

### DIFF
--- a/src/main/__tests__/mainLifecycle.test.ts
+++ b/src/main/__tests__/mainLifecycle.test.ts
@@ -1,0 +1,176 @@
+import type { Event as ElectronEvent } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const context = vi.hoisted(() => {
+  const appHandlers = new Map<string, (...args: unknown[]) => void>()
+
+  return {
+    appHandlers,
+    appQuit: vi.fn(),
+    cleanupDockBadge: vi.fn(),
+    log: vi.fn(),
+    setQuitting: vi.fn(),
+    stopMarkdownWatcher: vi.fn(),
+    stopTasksCleanupScheduler: vi.fn(),
+    stopThemeWatcher: vi.fn(),
+    storeAppSet: vi.fn(),
+  }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    commandLine: {
+      appendSwitch: vi.fn(),
+    },
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      context.appHandlers.set(event, handler)
+    }),
+    quit: context.appQuit,
+    requestSingleInstanceLock: () => true,
+    setAsDefaultProtocolClient: vi.fn(),
+    whenReady: () => new Promise(() => {}),
+  },
+  BrowserWindow: {
+    getFocusedWindow: () => null,
+  },
+  ipcMain: {
+    once: vi.fn(),
+  },
+  Menu: {
+    setApplicationMenu: vi.fn(),
+  },
+  protocol: {
+    handle: vi.fn(),
+  },
+  screen: {
+    getAllDisplays: () => [],
+  },
+}))
+
+vi.mock('../api', () => ({ initApi: vi.fn() }))
+vi.mock('../dockBadge', () => ({
+  cleanupDockBadge: context.cleanupDockBadge,
+  refreshDockBadge: vi.fn(),
+}))
+vi.mock('../folderIcons', () => ({ resolveFolderIconResponse: vi.fn() }))
+vi.mock('../ipc', () => ({ registerIPC: vi.fn() }))
+vi.mock('../ipc/handlers/theme', () => ({
+  startThemeWatcher: vi.fn(),
+  stopThemeWatcher: context.stopThemeWatcher,
+}))
+vi.mock('../license', () => ({ validateStoredLicense: vi.fn() }))
+vi.mock('../menu/main', () => ({ createMainMenu: vi.fn() }))
+vi.mock('../quitState', () => ({
+  isQuitting: () => false,
+  setQuitting: context.setQuitting,
+}))
+vi.mock('../storage', () => ({
+  prepareMarkdownWatcher: vi.fn(),
+  startMarkdownWatcher: vi.fn(),
+  stopMarkdownWatcher: context.stopMarkdownWatcher,
+}))
+vi.mock('../storage/providers/markdown/notes/runtime', () => ({
+  getNotesPaths: vi.fn(),
+  resolveNotesAsset: vi.fn(),
+}))
+vi.mock('../storage/providers/markdown/runtime/paths', () => ({
+  getVaultPath: vi.fn(),
+}))
+vi.mock('../storage/providers/markdown/runtime/spaces', () => ({
+  ensureFlatSpacesLayout: vi.fn(),
+}))
+vi.mock('../store', () => ({
+  store: {
+    app: {
+      get: vi.fn(),
+      set: context.storeAppSet,
+    },
+    preferences: {
+      get: vi.fn(),
+    },
+  },
+}))
+vi.mock('../tasks', () => ({
+  startTasksCleanupScheduler: vi.fn(),
+  stopTasksCleanupScheduler: context.stopTasksCleanupScheduler,
+}))
+vi.mock('../updates', () => ({ checkForUpdates: vi.fn() }))
+vi.mock('../utils', () => ({
+  isSqliteFile: () => false,
+  log: context.log,
+}))
+vi.mock('../windowBounds', () => ({
+  DEFAULT_WINDOW_BOUNDS: {},
+  normalizeWindowBounds: vi.fn(),
+}))
+
+const { handleBeforeQuit, handleMainWindowClose } = await import('../index')
+
+function createEvent(): ElectronEvent {
+  return {
+    preventDefault: vi.fn(),
+  } as unknown as ElectronEvent
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('main process safe quit lifecycle', () => {
+  it('cancels quit before any other cleanup when state flush fails', () => {
+    const event = createEvent()
+    context.stopMarkdownWatcher.mockImplementationOnce(() => {
+      throw new Error('Pending state writes remain')
+    })
+
+    handleBeforeQuit(event)
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(context.setQuitting).toHaveBeenCalledWith(false)
+    expect(context.log).toHaveBeenCalledWith(
+      'Error stopping markdown watcher before quit',
+      expect.any(Error),
+    )
+    expect(context.storeAppSet).not.toHaveBeenCalled()
+    expect(context.stopThemeWatcher).not.toHaveBeenCalled()
+    expect(context.stopTasksCleanupScheduler).not.toHaveBeenCalled()
+    expect(context.cleanupDockBadge).not.toHaveBeenCalled()
+  })
+
+  it('continues normal cleanup after state flush succeeds', () => {
+    const event = createEvent()
+
+    handleBeforeQuit(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(context.setQuitting).toHaveBeenCalledWith(true)
+    expect(context.stopThemeWatcher).toHaveBeenCalledTimes(1)
+    expect(context.stopTasksCleanupScheduler).toHaveBeenCalledTimes(1)
+    expect(context.cleanupDockBadge).toHaveBeenCalledTimes(1)
+    expect(context.appQuit).not.toHaveBeenCalled()
+  })
+
+  it('requests safe quit without destroying a non-macOS window on failure', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    const closeEvent = createEvent()
+    const quitEvent = createEvent()
+    const window = {
+      destroy: vi.fn(),
+      hide: vi.fn(),
+    }
+    context.stopMarkdownWatcher.mockImplementationOnce(() => {
+      throw new Error('Pending state writes remain')
+    })
+    context.appQuit.mockImplementationOnce(() => {
+      context.appHandlers.get('before-quit')?.(quitEvent)
+    })
+
+    handleMainWindowClose(closeEvent, window as never)
+
+    expect(closeEvent.preventDefault).toHaveBeenCalledTimes(1)
+    expect(context.appQuit).toHaveBeenCalledTimes(1)
+    expect(quitEvent.preventDefault).toHaveBeenCalledTimes(1)
+    expect(window.destroy).not.toHaveBeenCalled()
+    expect(window.hide).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable node/prefer-global/process */
+import type { Event as ElectronEvent } from 'electron'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { app, BrowserWindow, ipcMain, Menu, protocol, screen } from 'electron'
@@ -79,6 +80,45 @@ function flushWindowBoundsSave() {
   saveWindowBounds()
 }
 
+export function handleMainWindowClose(
+  event: ElectronEvent,
+  window = mainWindow,
+): void {
+  if (!isQuitting()) {
+    event.preventDefault()
+
+    if (process.platform === 'darwin') {
+      flushWindowBoundsSave()
+      window.hide()
+    }
+    else {
+      app.quit()
+    }
+    return
+  }
+
+  flushWindowBoundsSave()
+  window.destroy()
+}
+
+export function handleBeforeQuit(event: ElectronEvent): void {
+  try {
+    stopMarkdownWatcher()
+  }
+  catch (error) {
+    event.preventDefault()
+    setQuitting(false)
+    log('Error stopping markdown watcher before quit', error)
+    return
+  }
+
+  setQuitting(true)
+  flushWindowBoundsSave()
+  stopThemeWatcher()
+  stopTasksCleanupScheduler()
+  cleanupDockBadge()
+}
+
 if (process.defaultApp) {
   if (process.argv.length >= 2) {
     app.setAsDefaultProtocolClient('masscode', process.execPath, [
@@ -133,17 +173,7 @@ function createWindow() {
   mainWindow.on('move', scheduleWindowBoundsSave)
   mainWindow.on('resize', scheduleWindowBoundsSave)
 
-  mainWindow.on('close', (event) => {
-    flushWindowBoundsSave()
-
-    if (process.platform === 'darwin' && !isQuitting()) {
-      event.preventDefault()
-      mainWindow.hide()
-      return
-    }
-
-    mainWindow.destroy()
-  })
+  mainWindow.on('close', handleMainWindowClose)
 }
 
 if (!gotTheLock) {
@@ -298,14 +328,7 @@ else {
     mainWindow.show()
   })
 
-  app.on('before-quit', () => {
-    setQuitting(true)
-    flushWindowBoundsSave()
-    stopThemeWatcher()
-    stopMarkdownWatcher()
-    stopTasksCleanupScheduler()
-    cleanupDockBadge()
-  })
+  app.on('before-quit', handleBeforeQuit)
 
   app.on('window-all-closed', () => {
     if (process.platform !== 'darwin')

--- a/src/main/storage/providers/markdown/__tests__/watcherLifecycle.test.ts
+++ b/src/main/storage/providers/markdown/__tests__/watcherLifecycle.test.ts
@@ -49,6 +49,13 @@ async function setup() {
   )
   const syncHttpRuntimeWithDisk = vi.fn()
   const resetCloudDownloads = vi.fn()
+  const flushPendingStateWritesOrThrow = vi.fn()
+  const resetStateWriter = vi.fn()
+  const resetRuntimeCache = vi.fn()
+  const resetNotesRuntimeCache = vi.fn()
+  const resetHttpRuntimeCache = vi.fn()
+  const resetPathsCache = vi.fn()
+  const resetNotesPathsCache = vi.fn()
   const getPendingCloudPaths = vi.fn(() => ['/vault/.masscode/state.json'])
   const configureCloudDownloads = vi.fn(
     (configuration: CloudDownloadConfiguration) => {
@@ -94,7 +101,7 @@ async function setup() {
   vi.doMock('../http', () => ({
     getHttpPaths: vi.fn(() => httpPaths),
     peekHttpRuntimeCache: vi.fn(() => null),
-    resetHttpRuntimeCache: vi.fn(),
+    resetHttpRuntimeCache,
     syncHttpRuntimeWithDisk,
   }))
 
@@ -112,8 +119,8 @@ async function setup() {
     parseNotesAssetName: vi.fn((fileName: string) => ({ fileName })),
     peekNotesRuntimeCache,
     refreshPendingNoteFiles: vi.fn(() => ({ changed: false, remaining: 0 })),
-    resetNotesPathsCache: vi.fn(),
-    resetNotesRuntimeCache: vi.fn(),
+    resetNotesPathsCache,
+    resetNotesRuntimeCache,
     scheduleNotesAssetsMigration,
     syncNoteFileWithDisk: vi.fn(),
     syncNotesRuntimeWithDisk,
@@ -132,8 +139,8 @@ async function setup() {
       changed: false,
       remaining: 0,
     })),
-    resetPathsCache: vi.fn(),
-    resetRuntimeCache: vi.fn(),
+    resetPathsCache,
+    resetRuntimeCache,
     syncRuntimeWithDisk,
     syncSnippetFileWithDisk: vi.fn(),
   }))
@@ -156,6 +163,11 @@ async function setup() {
       && error.message.startsWith('CLOUD_FILE_NOT_DOWNLOADED'),
   }))
 
+  vi.doMock('../runtime/shared/stateWriter', () => ({
+    flushPendingStateWritesOrThrow,
+    resetStateWriter,
+  }))
+
   const { prepareMarkdownWatcher, startMarkdownWatcher, stopMarkdownWatcher }
     = await import('../watcher')
 
@@ -164,6 +176,7 @@ async function setup() {
     broadcastNotesAssetReady,
     configureCloudDownloads,
     ensureStateFile,
+    flushPendingStateWritesOrThrow,
     getPaths,
     getPendingCloudPaths,
     importEsm,
@@ -173,6 +186,12 @@ async function setup() {
     peekNotesRuntimeCache,
     prepareMarkdownWatcher,
     resetCloudDownloads,
+    resetHttpRuntimeCache,
+    resetNotesPathsCache,
+    resetNotesRuntimeCache,
+    resetPathsCache,
+    resetRuntimeCache,
+    resetStateWriter,
     scheduleNotesAssetsMigration,
     send,
     startMarkdownWatcher,
@@ -181,6 +200,7 @@ async function setup() {
     syncNotesRuntimeWithDisk,
     syncRuntimeWithDisk,
     watch,
+    watcher,
     watcherHandlers,
   }
 }
@@ -224,6 +244,62 @@ describe('markdown watcher cloud bootstrap', () => {
     context.startMarkdownWatcher()
 
     expect(context.resetCloudDownloads).toHaveBeenCalledTimes(2)
+  })
+
+  it('flushes and cleans state writes before resetting cloud downloads', async () => {
+    const context = await setup()
+    const lifecycleOrder: string[] = []
+    context.flushPendingStateWritesOrThrow.mockImplementation(() => {
+      lifecycleOrder.push('flush')
+    })
+    context.resetStateWriter.mockImplementation(() => {
+      lifecycleOrder.push('cleanup')
+    })
+    context.resetRuntimeCache.mockImplementation(() => {
+      lifecycleOrder.push('runtime-reset')
+    })
+    context.resetCloudDownloads.mockImplementation(() => {
+      lifecycleOrder.push('cloud-reset')
+    })
+
+    context.stopMarkdownWatcher()
+
+    expect(lifecycleOrder).toEqual([
+      'flush',
+      'runtime-reset',
+      'cleanup',
+      'cloud-reset',
+    ])
+    expect(context.flushPendingStateWritesOrThrow).toHaveBeenCalledTimes(1)
+    expect(context.resetStateWriter).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the watcher running when state writes remain', async () => {
+    const context = await setup()
+    context.prepareMarkdownWatcher()
+    context.startMarkdownWatcher()
+    await flushImmediate()
+    vi.clearAllMocks()
+    context.flushPendingStateWritesOrThrow.mockImplementationOnce(() => {
+      throw new Error('Pending state writes remain for: state.json')
+    })
+
+    expect(() => context.stopMarkdownWatcher()).toThrow(
+      'Pending state writes remain',
+    )
+    expect(context.watcher.close).not.toHaveBeenCalled()
+    expect(context.resetStateWriter).not.toHaveBeenCalled()
+    expect(context.resetCloudDownloads).not.toHaveBeenCalled()
+    expect(context.resetRuntimeCache).not.toHaveBeenCalled()
+    expect(context.resetNotesRuntimeCache).not.toHaveBeenCalled()
+    expect(context.resetHttpRuntimeCache).not.toHaveBeenCalled()
+    expect(context.resetPathsCache).not.toHaveBeenCalled()
+    expect(context.resetNotesPathsCache).not.toHaveBeenCalled()
+
+    expect(() => context.stopMarkdownWatcher()).not.toThrow()
+    expect(context.watcher.close).toHaveBeenCalledTimes(1)
+    expect(context.resetStateWriter).toHaveBeenCalledTimes(1)
+    expect(context.resetCloudDownloads).toHaveBeenCalledTimes(1)
   })
 
   it('cancels a pending initial start when start is called again', async () => {

--- a/src/main/storage/providers/markdown/runtime/__tests__/resetLifecycle.test.ts
+++ b/src/main/storage/providers/markdown/runtime/__tests__/resetLifecycle.test.ts
@@ -1,0 +1,76 @@
+import type { MarkdownRuntimeCache } from '../types'
+import os from 'node:os'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runtimeRef } from '../cache'
+import { flushPendingStateWritesOrThrow } from '../shared/stateWriter'
+import { resetRuntimeCache } from '../sync'
+
+const reconciler = vi.hoisted(() => ({
+  abandon: vi.fn(),
+  begin: vi.fn(),
+  isReconciled: vi.fn(() => true),
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => os.tmpdir(),
+  },
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
+}))
+
+vi.mock('../../../../../store', () => ({
+  store: {
+    preferences: {
+      get: () => undefined,
+    },
+  },
+}))
+
+vi.mock('../../cloudDownloads', () => ({
+  enqueueCloudDownload: vi.fn(),
+  prioritizeCloudDownload: vi.fn(),
+}))
+
+vi.mock('../shared/stateWriter', () => ({
+  flushPendingStateWritesOrThrow: vi.fn(),
+}))
+
+vi.mock('../shared/vaultReconcile', () => ({
+  createVaultReconciler: () => reconciler,
+}))
+
+function createRuntimeCache(): MarkdownRuntimeCache {
+  return {
+    paths: {
+      vaultPath: '/vault/code',
+    },
+  } as MarkdownRuntimeCache
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  runtimeRef.cache = createRuntimeCache()
+})
+
+describe('resetRuntimeCache lifecycle', () => {
+  it('preserves runtime and reconciler state when pending writes remain', () => {
+    const cache = runtimeRef.cache
+    vi.mocked(flushPendingStateWritesOrThrow).mockImplementationOnce(() => {
+      throw new Error('Pending state writes remain')
+    })
+
+    expect(() => resetRuntimeCache()).toThrow('Pending state writes remain')
+    expect(runtimeRef.cache).toBe(cache)
+    expect(reconciler.abandon).not.toHaveBeenCalled()
+  })
+
+  it('abandons reconciliation and clears runtime after a successful flush', () => {
+    resetRuntimeCache()
+
+    expect(flushPendingStateWritesOrThrow).toHaveBeenCalledTimes(1)
+    expect(reconciler.abandon).toHaveBeenCalledWith('/vault/code')
+    expect(runtimeRef.cache).toBeNull()
+  })
+})

--- a/src/main/storage/providers/markdown/runtime/shared/__tests__/stateWriter.test.ts
+++ b/src/main/storage/providers/markdown/runtime/shared/__tests__/stateWriter.test.ts
@@ -12,16 +12,26 @@ import {
   stateContentCacheByPath,
   stateFlushTimerByPath,
 } from '../../cache'
+import { STATE_WRITE_DEBOUNCE_MS } from '../../constants'
 import {
   resetCloudFileExemptions,
   setDatalessProbeForTests,
 } from '../cloudFiles'
 import { createStateAdapter } from '../stateAdapter'
-import { scheduleStateFlush } from '../stateWriter'
+import {
+  flushPendingStateWrites,
+  flushPendingStateWritesOrThrow,
+  resetStateWriter,
+  scheduleStateFlush,
+} from '../stateWriter'
 
 vi.mock('../../../cloudDownloads', () => ({
   enqueueCloudDownload: vi.fn(),
   prioritizeCloudDownload: vi.fn(),
+}))
+
+vi.mock('../../../../../../utils', () => ({
+  log: vi.fn(),
 }))
 
 const tempDirs: string[] = []
@@ -47,15 +57,10 @@ function mockZeroBlockStateFile(statePath: string): void {
 }
 
 afterEach(() => {
-  for (const timer of stateFlushTimerByPath.values()) {
-    clearTimeout(timer)
-  }
-
-  pendingStateWriteByPath.clear()
-  stateContentCacheByPath.clear()
-  stateFlushTimerByPath.clear()
+  resetStateWriter()
   setDatalessProbeForTests(null)
   resetCloudFileExemptions()
+  vi.useRealTimers()
   vi.clearAllMocks()
   vi.restoreAllMocks()
 
@@ -91,6 +96,122 @@ describe('stateWriter cloud placeholder guard', () => {
     expect(pendingStateWriteByPath.get(statePath)).toBe('local state')
     expect(stateFlushTimerByPath.has(statePath)).toBe(true)
     expect(enqueueCloudDownload).toHaveBeenCalledWith(statePath)
+  })
+
+  it('cancels placeholder retries and clears writer state on reset', () => {
+    vi.useFakeTimers()
+    const statePath = createStatePath()
+    fs.ensureDirSync(path.dirname(statePath))
+    fs.writeFileSync(statePath, 'cloud state', 'utf8')
+    mockZeroBlockStateFile(statePath)
+    setDatalessProbeForTests(() => true)
+
+    scheduleStateFlush(statePath, 'local state', { immediate: true })
+    expect(enqueueCloudDownload).toHaveBeenCalledTimes(1)
+
+    resetStateWriter()
+    vi.advanceTimersByTime(5_000)
+
+    expect(enqueueCloudDownload).toHaveBeenCalledTimes(1)
+    expect(pendingStateWriteByPath.size).toBe(0)
+    expect(stateContentCacheByPath.size).toBe(0)
+    expect(stateFlushTimerByPath.size).toBe(0)
+  })
+
+  it('continues flushing other paths after an I/O error', () => {
+    vi.useFakeTimers()
+    const failedStatePath = createStatePath()
+    const successfulStatePath = createStatePath()
+    const writeFileSync = fs.writeFileSync.bind(fs)
+
+    scheduleStateFlush(failedStatePath, 'failed state')
+    scheduleStateFlush(successfulStatePath, 'successful state')
+    vi.spyOn(fs, 'writeFileSync').mockImplementation(
+      (filePath, data, options) => {
+        if (filePath === failedStatePath) {
+          const error = new Error('write failed') as NodeJS.ErrnoException
+          error.code = 'EIO'
+          throw error
+        }
+        return writeFileSync(filePath, data, options)
+      },
+    )
+
+    const result = flushPendingStateWrites()
+
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({ code: 'EIO' }),
+        statePath: failedStatePath,
+      }),
+    ])
+    expect(result.unresolvedPaths).toEqual([failedStatePath])
+    expect(pendingStateWriteByPath.get(failedStatePath)).toBe('failed state')
+    expect(stateFlushTimerByPath.has(failedStatePath)).toBe(true)
+    expect(pendingStateWriteByPath.has(successfulStatePath)).toBe(false)
+    expect(stateFlushTimerByPath.has(successfulStatePath)).toBe(false)
+    expect(fs.readFileSync(successfulStatePath, 'utf8')).toBe(
+      'successful state',
+    )
+
+    let thrownError: Error | null = null
+    try {
+      flushPendingStateWritesOrThrow()
+    }
+    catch (error) {
+      thrownError = error as Error
+    }
+    expect(thrownError?.message).toBe(
+      `Pending state writes remain for: ${failedStatePath}`,
+    )
+    expect(thrownError?.cause).toBeInstanceOf(AggregateError)
+  })
+
+  it('replaces a failed debounce timer with a retry and clears it on success', () => {
+    vi.useFakeTimers()
+    const statePath = createStatePath()
+    const writeFileSync = fs.writeFileSync.bind(fs)
+    const writeError = new Error('write failed') as NodeJS.ErrnoException
+    writeError.code = 'EIO'
+    vi.spyOn(fs, 'writeFileSync')
+      .mockImplementationOnce(() => {
+        throw writeError
+      })
+      .mockImplementation(writeFileSync)
+
+    scheduleStateFlush(statePath, 'next state')
+    const debounceTimer = stateFlushTimerByPath.get(statePath)
+
+    vi.advanceTimersByTime(STATE_WRITE_DEBOUNCE_MS)
+
+    const retryTimer = stateFlushTimerByPath.get(statePath)
+    expect(retryTimer).toBeDefined()
+    expect(retryTimer).not.toBe(debounceTimer)
+    expect(pendingStateWriteByPath.get(statePath)).toBe('next state')
+
+    vi.advanceTimersByTime(5_000)
+
+    expect(fs.readFileSync(statePath, 'utf8')).toBe('next state')
+    expect(pendingStateWriteByPath.has(statePath)).toBe(false)
+    expect(stateFlushTimerByPath.has(statePath)).toBe(false)
+  })
+
+  it('flushes a placeholder after it is hydrated before the retry', () => {
+    vi.useFakeTimers()
+    const statePath = createStatePath()
+    fs.ensureDirSync(path.dirname(statePath))
+    fs.writeFileSync(statePath, 'cloud state', 'utf8')
+    mockZeroBlockStateFile(statePath)
+    let isPlaceholder = true
+    setDatalessProbeForTests(() => isPlaceholder)
+
+    scheduleStateFlush(statePath, 'local state', { immediate: true })
+    isPlaceholder = false
+    vi.advanceTimersByTime(5_000)
+
+    expect(fs.readFileSync(statePath, 'utf8')).toBe('local state')
+    expect(pendingStateWriteByPath.has(statePath)).toBe(false)
+    expect(stateFlushTimerByPath.has(statePath)).toBe(false)
   })
 })
 

--- a/src/main/storage/providers/markdown/runtime/shared/stateAdapter.ts
+++ b/src/main/storage/providers/markdown/runtime/shared/stateAdapter.ts
@@ -5,7 +5,6 @@ import { markAppWrittenFileAsLocal } from './cloudFiles'
 import { readVaultTextFileSync } from './guardedRead'
 import {
   flushPendingStateWriteByPath,
-  registerStateWriteHooks,
   scheduleStateFlush,
 } from './stateWriter'
 
@@ -48,8 +47,6 @@ export function createStateAdapter<
   config: StateAdapterConfig<TState, TStateFile, TPaths>,
 ): StateAdapter<TState, TPaths> {
   function ensureStateFile(paths: TPaths): void {
-    registerStateWriteHooks()
-
     for (const dir of config.getDirs(paths)) {
       fs.ensureDirSync(dir)
     }

--- a/src/main/storage/providers/markdown/runtime/shared/stateWriter.ts
+++ b/src/main/storage/providers/markdown/runtime/shared/stateWriter.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
-import process from 'node:process'
 import fs from 'fs-extra'
+import { log } from '../../../../../utils'
 import { enqueueCloudDownload } from '../../cloudDownloads'
 import {
   pendingStateWriteByPath,
@@ -13,7 +13,38 @@ import { getFileAvailability, markAppWrittenFileAsLocal } from './cloudFiles'
 
 const CLOUD_STATE_FLUSH_RETRY_MS = 5_000
 
-let hooksRegistered = false
+export interface StateFlushResult {
+  errors: { error: unknown, statePath: string }[]
+  unresolvedPaths: string[]
+}
+
+function clearStateFlushTimer(statePath: string): void {
+  const timer = stateFlushTimerByPath.get(statePath)
+  if (!timer) {
+    return
+  }
+
+  clearTimeout(timer)
+  stateFlushTimerByPath.delete(statePath)
+}
+
+function replaceStateFlushTimer(statePath: string, delay: number): void {
+  clearStateFlushTimer(statePath)
+
+  const timer = setTimeout(() => {
+    if (stateFlushTimerByPath.get(statePath) === timer) {
+      stateFlushTimerByPath.delete(statePath)
+    }
+
+    try {
+      flushPath(statePath)
+    }
+    catch {
+      // flushPath logs the error, preserves pending and schedules the retry.
+    }
+  }, delay)
+  stateFlushTimerByPath.set(statePath, timer)
+}
 
 function getPersistedContent(statePath: string): string {
   const cached = stateContentCacheByPath.get(statePath)
@@ -40,32 +71,30 @@ function flushPath(statePath: string): void {
   if (pendingContent === undefined)
     return
 
-  const flushTimer = stateFlushTimerByPath.get(statePath)
-  if (flushTimer) {
-    clearTimeout(flushTimer)
-    stateFlushTimerByPath.delete(statePath)
-  }
-
   // State-файл вытеснен в облако: запись затёрла бы недокачанную версию.
   // Запись остаётся в pending и повторяется после докачки.
   if (getFileAvailability(statePath).isCloudPlaceholder) {
     enqueueCloudDownload(statePath)
-    const retryTimer = setTimeout(
-      () => flushPath(statePath),
-      CLOUD_STATE_FLUSH_RETRY_MS,
-    )
-    stateFlushTimerByPath.set(statePath, retryTimer)
+    replaceStateFlushTimer(statePath, CLOUD_STATE_FLUSH_RETRY_MS)
     return
   }
 
-  const persistedContent = getPersistedContent(statePath)
-  if (persistedContent !== pendingContent) {
-    fs.ensureDirSync(path.dirname(statePath))
-    fs.writeFileSync(statePath, pendingContent, 'utf8')
-    rememberAppFileChange(statePath)
-    markAppWrittenFileAsLocal(statePath)
+  try {
+    const persistedContent = getPersistedContent(statePath)
+    if (persistedContent !== pendingContent) {
+      fs.ensureDirSync(path.dirname(statePath))
+      fs.writeFileSync(statePath, pendingContent, 'utf8')
+      rememberAppFileChange(statePath)
+      markAppWrittenFileAsLocal(statePath)
+    }
+  }
+  catch (error) {
+    replaceStateFlushTimer(statePath, CLOUD_STATE_FLUSH_RETRY_MS)
+    log(`storage:markdown:state-flush:${statePath}`, error)
+    throw error
   }
 
+  clearStateFlushTimer(statePath)
   stateContentCacheByPath.set(statePath, pendingContent)
   pendingStateWriteByPath.delete(statePath)
 }
@@ -90,27 +119,64 @@ export function scheduleStateFlush(
     return
   }
 
-  const existing = stateFlushTimerByPath.get(statePath)
-  if (existing)
-    clearTimeout(existing)
-
-  const timer = setTimeout(() => flushPath(statePath), STATE_WRITE_DEBOUNCE_MS)
-  stateFlushTimerByPath.set(statePath, timer)
+  replaceStateFlushTimer(statePath, STATE_WRITE_DEBOUNCE_MS)
 }
 
 export function flushPendingStateWriteByPath(statePath: string): void {
   flushPath(statePath)
 }
 
-export function flushPendingStateWrites(): void {
+export function flushPendingStateWrites(): StateFlushResult {
   const paths = [...pendingStateWriteByPath.keys()]
-  paths.forEach(statePath => flushPath(statePath))
+  const errors: StateFlushResult['errors'] = []
+
+  for (const statePath of paths) {
+    try {
+      flushPath(statePath)
+    }
+    catch (error) {
+      errors.push({ error, statePath })
+    }
+  }
+
+  return {
+    errors,
+    unresolvedPaths: paths.filter(statePath =>
+      pendingStateWriteByPath.has(statePath),
+    ),
+  }
 }
 
-export function registerStateWriteHooks(): void {
-  if (hooksRegistered)
+export function flushPendingStateWritesOrThrow(): void {
+  const result = flushPendingStateWrites()
+  if (!result.errors.length && !result.unresolvedPaths.length) {
     return
-  hooksRegistered = true
-  process.once('beforeExit', flushPendingStateWrites)
-  process.once('exit', flushPendingStateWrites)
+  }
+
+  const affectedPaths = [
+    ...new Set([
+      ...result.unresolvedPaths,
+      ...result.errors.map(entry => entry.statePath),
+    ]),
+  ]
+  const error = new Error(
+    `Pending state writes remain for: ${affectedPaths.join(', ')}`,
+  )
+  if (result.errors.length) {
+    error.cause = new AggregateError(
+      result.errors.map(entry => entry.error),
+      'Failed to flush pending state writes',
+    )
+  }
+  throw error
+}
+
+export function resetStateWriter(): void {
+  for (const timer of stateFlushTimerByPath.values()) {
+    clearTimeout(timer)
+  }
+
+  pendingStateWriteByPath.clear()
+  stateContentCacheByPath.clear()
+  stateFlushTimerByPath.clear()
 }

--- a/src/main/storage/providers/markdown/runtime/sync.ts
+++ b/src/main/storage/providers/markdown/runtime/sync.ts
@@ -31,6 +31,7 @@ import {
 } from './shared/folderSync'
 import { isCloudFileNotDownloadedError } from './shared/guardedRead'
 import { syncFolderUiWithFolders } from './shared/stateUtils'
+import { flushPendingStateWritesOrThrow } from './shared/stateWriter'
 import { createVaultReconciler } from './shared/vaultReconcile'
 import {
   buildSnippetIndexMetadata,
@@ -45,7 +46,6 @@ import {
 import {
   createDefaultState,
   flushPendingStateWrite,
-  flushPendingStateWrites,
   loadState,
   saveState,
 } from './state'
@@ -265,7 +265,7 @@ export function setRuntimeCache(
 const vaultReconciler = createVaultReconciler('markdown')
 
 export function resetRuntimeCache(): void {
-  flushPendingStateWrites()
+  flushPendingStateWritesOrThrow()
   // Смена vault: ретраи сверки брошенного корня останавливаются, иначе они
   // продолжили бы попытки по неактивному пути и слали storage-synced.
   const previousVaultPath = runtimeRef.cache?.paths.vaultPath

--- a/src/main/storage/providers/markdown/watcher.ts
+++ b/src/main/storage/providers/markdown/watcher.ts
@@ -44,6 +44,10 @@ import {
 import { wasRecentAppFileChange } from './runtime/shared/appChanges'
 import { getFileAvailability } from './runtime/shared/cloudFiles'
 import { isCloudFileNotDownloadedError } from './runtime/shared/guardedRead'
+import {
+  flushPendingStateWritesOrThrow,
+  resetStateWriter,
+} from './runtime/shared/stateWriter'
 import { broadcastStorageSynced } from './runtime/shared/vaultReconcile'
 import {
   getManagedNotesAssetName,
@@ -422,6 +426,10 @@ function scheduleCloudRefresh(
 }
 
 export function stopMarkdownWatcher(): void {
+  // Flush while cloud exemptions still identify app-written files as local.
+  // Any unresolved write leaves the watcher and all retry state untouched.
+  flushPendingStateWritesOrThrow()
+
   watcherStartToken += 1
   preparedCloudVaultPath = null
   preparedWatcherStartToken = null
@@ -451,12 +459,13 @@ export function stopMarkdownWatcher(): void {
   hasPendingNotesSync = false
   hasPendingHttpSync = false
   hasPendingDrawingsSync = false
-  resetCloudDownloads()
   resetRuntimeCache()
   resetNotesRuntimeCache()
   resetHttpRuntimeCache()
   resetPathsCache()
   resetNotesPathsCache()
+  resetStateWriter()
+  resetCloudDownloads()
 }
 
 function initializeMarkdownWatcher(vaultRootPath: string): void {


### PR DESCRIPTION
## Summary

- prevent runtime resets and app shutdown from discarding pending state writes
- retry state writes after I/O failures while preserving one timer per path
- cancel quit and keep the window alive when state cannot be safely flushed
- add focused writer, watcher, runtime reset, and main lifecycle coverage