### PR TITLE
fix(http): handle local zero-block request files

### DIFF
--- a/src/main/storage/providers/markdown/http/runtime/parser.ts
+++ b/src/main/storage/providers/markdown/http/runtime/parser.ts
@@ -14,7 +14,10 @@ import yaml from 'js-yaml'
 import { log } from '../../../../../utils'
 import { enqueueCloudDownload } from '../../cloudDownloads'
 import { normalizeFlag } from '../../runtime/normalizers'
-import { getFileAvailability } from '../../runtime/shared/cloudFiles'
+import {
+  getFileAvailability,
+  markAppWrittenFileAsLocal,
+} from '../../runtime/shared/cloudFiles'
 import { throwCloudContentUnavailable } from '../../runtime/shared/cloudGuards'
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
@@ -285,20 +288,28 @@ export function ensureRequestDetailsLoaded(
   return true
 }
 
+const trustedMovedLocalWrite = Symbol('trusted-moved-local-write')
+
 export function writeRequestFile(
   httpRoot: string,
   record: HttpRequestRecord,
-  options?: { skipIfUnavailable?: boolean },
+  options?: {
+    skipIfUnavailable?: boolean
+    [trustedMovedLocalWrite]?: true
+  },
 ): void {
   const absolutePath = path.join(httpRoot, record.filePath)
-  const availability = getFileAvailability(absolutePath)
+  const canWriteMovedLocalFile = options?.[trustedMovedLocalWrite] === true
+  const availability = canWriteMovedLocalFile
+    ? null
+    : getFileAvailability(absolutePath)
 
   // Запись в недокачанный файл затёрла бы облачное содержимое: файл сначала
   // докачивается в фоне. По умолчанию сбой поднимается наверх: тихий пропуск
   // означал бы «принятую» правку, которую докачка затем молча перезапишет
   // облачным содержимым. Пропуск допустим только в необязательном write-back
   // scan-пути.
-  if (record.pendingCloudDownload || availability.isCloudPlaceholder) {
+  if (record.pendingCloudDownload || availability?.isCloudPlaceholder) {
     enqueueCloudDownload(absolutePath)
     if (options?.skipIfUnavailable) {
       return
@@ -317,13 +328,31 @@ export function writeRequestFile(
 
   const next = serializeRequestFile(record)
 
-  if (availability.exists) {
+  // Trusted move bypasses only the second availability classification. The
+  // destination is still read by pathname before any mark/write: read failure
+  // aborts without granting a zero-block exemption. This intentionally follows
+  // the same provider trust boundary as Code/Notes; Node cannot atomically
+  // guard against a same-inode dehydrate/replace between move and pathname I/O.
+  if (canWriteMovedLocalFile || availability?.exists) {
     const current = fs.readFileSync(absolutePath, 'utf8')
     if (current === next) {
+      if (canWriteMovedLocalFile) {
+        markAppWrittenFileAsLocal(absolutePath)
+      }
       return
     }
   }
 
   fs.ensureDirSync(path.dirname(absolutePath))
   fs.writeFileSync(absolutePath, next, 'utf8')
+  markAppWrittenFileAsLocal(absolutePath)
+}
+
+export function writeVerifiedMovedLocalRequestFile(
+  httpRoot: string,
+  record: HttpRequestRecord,
+): void {
+  writeRequestFile(httpRoot, record, {
+    [trustedMovedLocalWrite]: true,
+  })
 }

--- a/src/main/storage/providers/markdown/http/storages/__tests__/folders.test.ts
+++ b/src/main/storage/providers/markdown/http/storages/__tests__/folders.test.ts
@@ -1,0 +1,384 @@
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { enqueueCloudDownload } from '../../../cloudDownloads'
+import {
+  getFileAvailability,
+  resetCloudFileExemptions,
+  setDatalessProbeForTests,
+} from '../../../runtime/shared/cloudFiles'
+import { getHttpPaths } from '../../runtime/paths'
+import { ensureHttpStateFile } from '../../runtime/state'
+import { getHttpRuntimeCache, resetHttpRuntimeCache } from '../../runtime/sync'
+import { createHttpFoldersStorage } from '../folders'
+import { createHttpRequestsStorage } from '../requests'
+
+let tempVaultPath = ''
+
+function makeSparsePlaceholder(absolutePath: string, size = 4096): void {
+  fs.removeSync(absolutePath)
+  const fd = fs.openSync(absolutePath, 'w')
+  fs.ftruncateSync(fd, size)
+  fs.closeSync(fd)
+}
+
+function mockMarkdownFilesAsZeroBlocks() {
+  const statSync = fs.statSync.bind(fs)
+
+  return vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+    const stats = statSync(filePath)
+
+    if (
+      typeof filePath === 'string'
+      && filePath.endsWith('.md')
+      && stats.size > 0
+    ) {
+      return Object.assign(stats, { blocks: 0 })
+    }
+
+    return stats
+  })
+}
+
+vi.mock('electron-store', () => {
+  class MockStore {
+    private state: Record<string, unknown>
+
+    constructor(options?: { defaults?: Record<string, unknown> }) {
+      this.state = { ...(options?.defaults || {}) }
+    }
+
+    get(key?: string): unknown {
+      if (!key) {
+        return this.state
+      }
+
+      return key.split('.').reduce<unknown>((acc, segment) => {
+        if (!acc || typeof acc !== 'object') {
+          return undefined
+        }
+
+        return (acc as Record<string, unknown>)[segment]
+      }, this.state)
+    }
+
+    set(key: string, value: unknown): void {
+      const segments = key.split('.')
+      let cursor: Record<string, unknown> = this.state
+
+      for (let index = 0; index < segments.length - 1; index += 1) {
+        const segment = segments[index]
+        const next = cursor[segment]
+
+        if (!next || typeof next !== 'object') {
+          cursor[segment] = {}
+        }
+
+        cursor = cursor[segment] as Record<string, unknown>
+      }
+
+      cursor[segments[segments.length - 1]] = value
+    }
+  }
+
+  return { default: MockStore }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => os.tmpdir(),
+  },
+}))
+
+vi.mock('../../../cloudDownloads', () => ({
+  enqueueCloudDownload: vi.fn(),
+  prioritizeCloudDownload: vi.fn(),
+}))
+
+vi.mock('../../../../../../store', () => ({
+  store: {
+    preferences: {
+      get: (key: string) => {
+        if (key === 'storage.vaultPath') {
+          return tempVaultPath
+        }
+
+        return undefined
+      },
+    },
+  },
+}))
+
+describe('http folders storage', () => {
+  beforeEach(() => {
+    tempVaultPath = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'http-folders-storage-'),
+    )
+    resetHttpRuntimeCache()
+    ensureHttpStateFile(getHttpPaths(tempVaultPath))
+  })
+
+  afterEach(() => {
+    setDatalessProbeForTests(null)
+    resetCloudFileExemptions()
+    resetHttpRuntimeCache()
+    fs.removeSync(tempVaultPath)
+    tempVaultPath = ''
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('moves resident zero-block requests to trash when deleting a folder', () => {
+    const paths = getHttpPaths(tempVaultPath)
+    setDatalessProbeForTests(() => true)
+    const statSpy = mockMarkdownFilesAsZeroBlocks()
+
+    try {
+      const folders = createHttpFoldersStorage()
+      const requests = createHttpRequestsStorage()
+      const folder = folders.createFolder({ name: 'Resident Folder' })
+      const { id } = requests.createRequest({
+        folderId: folder.id,
+        name: 'Resident',
+      })
+
+      expect(folders.deleteFolder(folder.id)).toEqual({ deleted: true })
+      expect(() =>
+        requests.updateRequest(id, { description: 'still writable' }),
+      ).not.toThrow()
+
+      const record = getHttpRuntimeCache(paths).requestById.get(id)!
+      expect(record.folderId).toBeNull()
+      expect(record.isDeleted).toBe(1)
+      expect(
+        fs.readFileSync(path.join(paths.httpRoot, record.filePath), 'utf8'),
+      ).toContain('still writable')
+    }
+    finally {
+      statSpy.mockRestore()
+    }
+  })
+
+  it('deletes a folder when a later planned request source is missing', () => {
+    const paths = getHttpPaths(tempVaultPath)
+    const folders = createHttpFoldersStorage()
+    const requests = createHttpRequestsStorage()
+    const folder = folders.createFolder({ name: 'Mixed Folder' })
+    const resident = requests.createRequest({
+      folderId: folder.id,
+      name: 'Resident',
+    })
+    const missing = requests.createRequest({
+      folderId: folder.id,
+      name: 'Missing',
+    })
+    const cache = getHttpRuntimeCache(paths)
+    const missingRecord = cache.requestById.get(missing.id)!
+
+    fs.removeSync(path.join(paths.httpRoot, missingRecord.filePath))
+
+    expect(folders.deleteFolder(folder.id)).toEqual({ deleted: true })
+
+    const residentRecord = cache.requestById.get(resident.id)!
+    expect(residentRecord.filePath).toBe('Resident.md')
+    expect(residentRecord.folderId).toBeNull()
+    expect(residentRecord.isDeleted).toBe(1)
+    expect(missingRecord.filePath).toBe('Missing.md')
+    expect(missingRecord.folderId).toBeNull()
+    expect(missingRecord.isDeleted).toBe(1)
+    expect(fs.pathExistsSync(path.join(paths.httpRoot, 'Resident.md'))).toBe(
+      true,
+    )
+    expect(fs.pathExistsSync(path.join(paths.httpRoot, 'Missing.md'))).toBe(
+      true,
+    )
+    expect(
+      cache.state.requests.find(item => item.id === resident.id)?.filePath,
+    ).toBe('Resident.md')
+    expect(
+      cache.state.requests.find(item => item.id === missing.id)?.filePath,
+    ).toBe('Missing.md')
+    expect(folders.getFolders().some(item => item.id === folder.id)).toBe(
+      false,
+    )
+  })
+
+  it('reserves trash targets case-insensitively before deleting', () => {
+    const paths = getHttpPaths(tempVaultPath)
+    const folders = createHttpFoldersStorage()
+    const requests = createHttpRequestsStorage()
+    const root = folders.createFolder({ name: 'Root' })
+    const upperFolder = folders.createFolder({
+      name: 'Upper',
+      parentId: root.id,
+    })
+    const lowerFolder = folders.createFolder({
+      name: 'Lower',
+      parentId: root.id,
+    })
+    const upper = requests.createRequest({
+      folderId: upperFolder.id,
+      name: 'Foo',
+    })
+    const lower = requests.createRequest({
+      folderId: lowerFolder.id,
+      name: 'foo',
+    })
+
+    expect(folders.deleteFolder(root.id)).toEqual({ deleted: true })
+
+    const cache = getHttpRuntimeCache(paths)
+    const upperRecord = cache.requestById.get(upper.id)!
+    const lowerRecord = cache.requestById.get(lower.id)!
+    expect(upperRecord.filePath).toBe('Foo.md')
+    expect(lowerRecord.filePath).toBe('foo 1.md')
+    expect(upperRecord.isDeleted).toBe(1)
+    expect(lowerRecord.isDeleted).toBe(1)
+    expect(fs.pathExistsSync(path.join(paths.httpRoot, 'Foo.md'))).toBe(true)
+    expect(fs.pathExistsSync(path.join(paths.httpRoot, 'foo 1.md'))).toBe(true)
+    expect(folders.getFolders().some(folder => folder.id === root.id)).toBe(
+      false,
+    )
+  })
+
+  it('blocks folder deletion before mutating a genuine placeholder', () => {
+    const paths = getHttpPaths(tempVaultPath)
+    const folders = createHttpFoldersStorage()
+    const requests = createHttpRequestsStorage()
+    const folder = folders.createFolder({ name: 'Cloud Folder' })
+    const resident = requests.createRequest({
+      folderId: folder.id,
+      name: 'Resident',
+    })
+    const { id } = requests.createRequest({
+      folderId: folder.id,
+      name: 'Cloud Placeholder',
+    })
+    const record = getHttpRuntimeCache(paths).requestById.get(id)!
+    const sourcePath = path.join(paths.httpRoot, record.filePath)
+
+    makeSparsePlaceholder(sourcePath)
+    resetCloudFileExemptions()
+    setDatalessProbeForTests(() => true)
+    const statSpy = mockMarkdownFilesAsZeroBlocks()
+    const moveSpy = vi.spyOn(fs, 'moveSync')
+    const sourceBefore = fs.readFileSync(sourcePath)
+    const residentRecord = getHttpRuntimeCache(paths).requestById.get(
+      resident.id,
+    )!
+    const residentPath = path.join(paths.httpRoot, residentRecord.filePath)
+
+    try {
+      expect(() => folders.deleteFolder(folder.id)).toThrow(
+        'CLOUD_FILE_NOT_DOWNLOADED',
+      )
+
+      expect(fs.readFileSync(sourcePath)).toEqual(sourceBefore)
+      expect(fs.pathExistsSync(residentPath)).toBe(true)
+      expect(moveSpy).not.toHaveBeenCalled()
+      expect(folders.getFolders().some(item => item.id === folder.id)).toBe(
+        true,
+      )
+      expect(record.folderId).toBe(folder.id)
+      expect(record.isDeleted).toBe(0)
+    }
+    finally {
+      moveSpy.mockRestore()
+      statSpy.mockRestore()
+    }
+  })
+
+  it('marks a verified resident only after folder rename succeeds', async () => {
+    const paths = getHttpPaths(tempVaultPath)
+    setDatalessProbeForTests(() => true)
+    const statSpy = mockMarkdownFilesAsZeroBlocks()
+
+    try {
+      const folders = createHttpFoldersStorage()
+      const requests = createHttpRequestsStorage()
+      const folder = folders.createFolder({ name: 'Before' })
+      const { id } = requests.createRequest({
+        folderId: folder.id,
+        name: 'Resident',
+      })
+      const sourcePath = path.join(paths.httpRoot, 'Before/Resident.md')
+      const targetPath = path.join(paths.httpRoot, 'After/Resident.md')
+      const cloudFiles = await import('../../../runtime/shared/cloudFiles')
+      const markAppWrittenFileAsLocal
+        = cloudFiles.markAppWrittenFileAsLocal.bind(cloudFiles)
+      const markSpy = vi
+        .spyOn(cloudFiles, 'markAppWrittenFileAsLocal')
+        .mockImplementation((absolutePath) => {
+          if (absolutePath === targetPath) {
+            expect(fs.pathExistsSync(sourcePath)).toBe(false)
+            expect(fs.pathExistsSync(targetPath)).toBe(true)
+          }
+          markAppWrittenFileAsLocal(absolutePath)
+        })
+
+      try {
+        expect(() =>
+          folders.updateFolder(folder.id, { name: 'After' }),
+        ).not.toThrow()
+        expect(markSpy).toHaveBeenCalledWith(targetPath)
+        expect(() =>
+          requests.updateRequest(id, { description: 'still writable' }),
+        ).not.toThrow()
+
+        const record = getHttpRuntimeCache(paths).requestById.get(id)!
+        expect(record.filePath).toBe('After/Resident.md')
+      }
+      finally {
+        markSpy.mockRestore()
+      }
+    }
+    finally {
+      statSpy.mockRestore()
+    }
+  })
+
+  it('moves and requeues a pending placeholder without marking it', async () => {
+    const paths = getHttpPaths(tempVaultPath)
+    const folders = createHttpFoldersStorage()
+    const requests = createHttpRequestsStorage()
+    const folder = folders.createFolder({ name: 'Before' })
+    const { id } = requests.createRequest({
+      folderId: folder.id,
+      name: 'Cloud Placeholder',
+    })
+    const record = getHttpRuntimeCache(paths).requestById.get(id)!
+    const sourcePath = path.join(paths.httpRoot, record.filePath)
+    const targetPath = path.join(paths.httpRoot, 'After/Cloud Placeholder.md')
+
+    makeSparsePlaceholder(sourcePath)
+    record.pendingCloudDownload = true
+    resetCloudFileExemptions()
+    setDatalessProbeForTests(() => true)
+    const statSpy = mockMarkdownFilesAsZeroBlocks()
+    const sourceBefore = fs.readFileSync(sourcePath)
+    vi.mocked(enqueueCloudDownload).mockClear()
+    const cloudFiles = await import('../../../runtime/shared/cloudFiles')
+    const markSpy = vi.spyOn(cloudFiles, 'markAppWrittenFileAsLocal')
+
+    try {
+      expect(() =>
+        folders.updateFolder(folder.id, { name: 'After' }),
+      ).not.toThrow()
+
+      expect(fs.pathExistsSync(sourcePath)).toBe(false)
+      expect(fs.readFileSync(targetPath)).toEqual(sourceBefore)
+      expect(getFileAvailability(targetPath).isCloudPlaceholder).toBe(true)
+      expect(enqueueCloudDownload).toHaveBeenCalledWith(targetPath)
+      expect(markSpy).not.toHaveBeenCalledWith(targetPath)
+      expect(() =>
+        requests.updateRequest(id, { description: 'must not be written' }),
+      ).toThrow('CLOUD_FILE_NOT_DOWNLOADED')
+    }
+    finally {
+      markSpy.mockRestore()
+      statSpy.mockRestore()
+    }
+  })
+})

--- a/src/main/storage/providers/markdown/http/storages/__tests__/requests.test.ts
+++ b/src/main/storage/providers/markdown/http/storages/__tests__/requests.test.ts
@@ -5,14 +5,44 @@ import yaml from 'js-yaml'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { stateContentCacheByPath } from '../../../runtime/cache'
-import { setDatalessProbeForTests } from '../../../runtime/shared/cloudFiles'
+import {
+  getFileAvailability,
+  resetCloudFileExemptions,
+  setDatalessProbeForTests,
+} from '../../../runtime/shared/cloudFiles'
 import { flushPendingStateWrites } from '../../../runtime/shared/stateWriter'
 import { getHttpPaths } from '../../runtime/paths'
 import { ensureHttpStateFile } from '../../runtime/state'
 import { getHttpRuntimeCache, resetHttpRuntimeCache } from '../../runtime/sync'
+import { createHttpFoldersStorage } from '../folders'
 import { createHttpRequestsStorage } from '../requests'
 
 let tempVaultPath = ''
+
+function makeSparsePlaceholder(absolutePath: string, size = 4096): void {
+  fs.removeSync(absolutePath)
+  const fd = fs.openSync(absolutePath, 'w')
+  fs.ftruncateSync(fd, size)
+  fs.closeSync(fd)
+}
+
+function mockMarkdownFilesAsZeroBlocks() {
+  const statSync = fs.statSync.bind(fs)
+
+  return vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+    const stats = statSync(filePath)
+
+    if (
+      typeof filePath === 'string'
+      && filePath.endsWith('.md')
+      && stats.size > 0
+    ) {
+      return Object.assign(stats, { blocks: 0 })
+    }
+
+    return stats
+  })
+}
 
 vi.mock('electron-store', () => {
   class MockStore {
@@ -94,10 +124,263 @@ describe('http requests storage', () => {
 
   afterEach(() => {
     setDatalessProbeForTests(null)
+    resetCloudFileExemptions()
     resetHttpRuntimeCache()
     fs.removeSync(tempVaultPath)
     tempVaultPath = ''
     vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('updates and renames an app-written resident zero-block request', () => {
+    const paths = getHttpPaths(tempVaultPath)
+    setDatalessProbeForTests((_absolutePath, stats) => stats.size === 4096)
+    const statSpy = mockMarkdownFilesAsZeroBlocks()
+
+    try {
+      const storage = createHttpRequestsStorage()
+      const { id } = storage.createRequest({ name: 'Resident' })
+      const sourcePath = path.join(paths.httpRoot, 'Resident.md')
+
+      expect(() =>
+        storage.updateRequest(id, {
+          body: 'resident body',
+          bodyType: 'text',
+        }),
+      ).not.toThrow()
+      const sourceIdentity = fs.lstatSync(sourcePath, { bigint: true })
+      expect(() =>
+        storage.updateRequest(id, { name: 'Resident Renamed' }),
+      ).not.toThrow()
+
+      const targetPath = path.join(paths.httpRoot, 'Resident Renamed.md')
+      const targetIdentity = fs.lstatSync(targetPath, { bigint: true })
+      expect(targetIdentity.dev).toBe(sourceIdentity.dev)
+      expect(targetIdentity.ino).toBe(sourceIdentity.ino)
+      expect(fs.readFileSync(targetPath, 'utf8')).toContain('resident body')
+      expect(getFileAvailability(targetPath).isCloudPlaceholder).toBe(false)
+    }
+    finally {
+      statSpy.mockRestore()
+    }
+  })
+
+  it('does not mark a trusted move when destination read fails', async () => {
+    const paths = getHttpPaths(tempVaultPath)
+    setDatalessProbeForTests(() => true)
+    const statSpy = mockMarkdownFilesAsZeroBlocks()
+    const storage = createHttpRequestsStorage()
+    const { id } = storage.createRequest({ name: 'Read Source' })
+    const targetPath = path.join(paths.httpRoot, 'Read Target.md')
+    const cloudFiles = await import('../../../runtime/shared/cloudFiles')
+    const markSpy = vi.spyOn(cloudFiles, 'markAppWrittenFileAsLocal')
+    const readFileSync = fs.readFileSync.bind(fs)
+    const readSpy = vi
+      .spyOn(fs, 'readFileSync')
+      .mockImplementation(
+        (filePath, options?: Parameters<typeof fs.readFileSync>[1]) => {
+          if (filePath === targetPath) {
+            throw new Error('trusted destination read failed')
+          }
+          return readFileSync(filePath, options as never) as never
+        },
+      )
+
+    try {
+      expect(() => storage.updateRequest(id, { name: 'Read Target' })).toThrow(
+        'trusted destination read failed',
+      )
+      expect(markSpy).not.toHaveBeenCalled()
+      expect(fs.pathExistsSync(targetPath)).toBe(true)
+    }
+    finally {
+      readSpy.mockRestore()
+      markSpy.mockRestore()
+      statSpy.mockRestore()
+    }
+  })
+
+  it('does not mark a trusted move when destination write fails', async () => {
+    const paths = getHttpPaths(tempVaultPath)
+    setDatalessProbeForTests(() => true)
+    const statSpy = mockMarkdownFilesAsZeroBlocks()
+    const storage = createHttpRequestsStorage()
+    const { id } = storage.createRequest({ name: 'Write Source' })
+    const targetPath = path.join(paths.httpRoot, 'Write Target.md')
+    const cloudFiles = await import('../../../runtime/shared/cloudFiles')
+    const markSpy = vi.spyOn(cloudFiles, 'markAppWrittenFileAsLocal')
+    const writeFileSync = fs.writeFileSync.bind(fs)
+    const writeSpy = vi
+      .spyOn(fs, 'writeFileSync')
+      .mockImplementation((filePath, data, options?) => {
+        if (filePath === targetPath) {
+          throw new Error('trusted destination write failed')
+        }
+        return writeFileSync(filePath, data, options as never)
+      })
+
+    try {
+      expect(() => storage.updateRequest(id, { name: 'Write Target' })).toThrow(
+        'trusted destination write failed',
+      )
+      expect(markSpy).not.toHaveBeenCalled()
+      expect(fs.pathExistsSync(targetPath)).toBe(true)
+    }
+    finally {
+      writeSpy.mockRestore()
+      markSpy.mockRestore()
+      statSpy.mockRestore()
+    }
+  })
+
+  it('keeps a genuine placeholder unchanged when update or rename is attempted', () => {
+    const paths = getHttpPaths(tempVaultPath)
+    const storage = createHttpRequestsStorage()
+    const { id } = storage.createRequest({ name: 'Cloud Placeholder' })
+    const record = getHttpRuntimeCache(paths).requestById.get(id)!
+    const sourcePath = path.join(paths.httpRoot, record.filePath)
+    const targetPath = path.join(paths.httpRoot, 'Renamed Placeholder.md')
+
+    makeSparsePlaceholder(sourcePath)
+    resetCloudFileExemptions()
+    setDatalessProbeForTests(() => true)
+    const statSpy = mockMarkdownFilesAsZeroBlocks()
+    const sourceBefore = fs.readFileSync(sourcePath)
+
+    try {
+      expect(() =>
+        storage.updateRequest(id, { description: 'must not be written' }),
+      ).toThrow('CLOUD_FILE_NOT_DOWNLOADED')
+      expect(() =>
+        storage.updateRequest(id, { name: 'Renamed Placeholder' }),
+      ).toThrow('CLOUD_FILE_NOT_DOWNLOADED')
+
+      expect(fs.readFileSync(sourcePath)).toEqual(sourceBefore)
+      expect(fs.pathExistsSync(targetPath)).toBe(false)
+      expect(storage.getRequests().find(item => item.id === id)?.name).toBe(
+        'Cloud Placeholder',
+      )
+    }
+    finally {
+      statSpy.mockRestore()
+    }
+  })
+
+  it('creates the resolved target when a rename source is missing', () => {
+    const paths = getHttpPaths(tempVaultPath)
+    const folders = createHttpFoldersStorage()
+    const storage = createHttpRequestsStorage()
+    const folder = folders.createFolder({ name: 'Target Folder' })
+    const { id } = storage.createRequest({ name: 'Missing Source' })
+    const record = getHttpRuntimeCache(paths).requestById.get(id)!
+    const sourcePath = path.join(paths.httpRoot, record.filePath)
+    const expectedFilePath = 'Target Folder/Missing Renamed.md'
+    const targetPath = path.join(paths.httpRoot, expectedFilePath)
+
+    fs.removeSync(sourcePath)
+
+    expect(() =>
+      storage.updateRequest(id, {
+        folderId: folder.id,
+        name: 'Missing Renamed',
+      }),
+    ).not.toThrow()
+
+    const cache = getHttpRuntimeCache(paths)
+    const updated = cache.requestById.get(id)!
+    const indexEntry = cache.state.requests.find(item => item.id === id)
+    expect(fs.pathExistsSync(sourcePath)).toBe(false)
+    expect(fs.pathExistsSync(targetPath)).toBe(true)
+    expect(updated.name).toBe('Missing Renamed')
+    expect(updated.folderId).toBe(folder.id)
+    expect(updated.filePath).toBe(expectedFilePath)
+    expect(indexEntry?.filePath).toBe(expectedFilePath)
+  })
+
+  it('does not move a source that appears after missing-source preflight', () => {
+    const paths = getHttpPaths(tempVaultPath)
+    const storage = createHttpRequestsStorage()
+    const { id } = storage.createRequest({ name: 'Late Source' })
+    const cache = getHttpRuntimeCache(paths)
+    const record = cache.requestById.get(id)!
+    const indexEntry = cache.state.requests.find(item => item.id === id)!
+    const sourcePath = path.join(paths.httpRoot, record.filePath)
+    const targetPath = path.join(paths.httpRoot, 'Must Not Move.md')
+    const originalPath = record.filePath
+    const recordBefore = { ...record }
+    const pathExistsSync = fs.pathExistsSync.bind(fs)
+    let injected = false
+
+    fs.removeSync(sourcePath)
+    const existsSpy = vi
+      .spyOn(fs, 'pathExistsSync')
+      .mockImplementation((filePath) => {
+        if (!injected && filePath === sourcePath) {
+          injected = true
+          fs.writeFileSync(sourcePath, 'late source', 'utf8')
+          return true
+        }
+        return pathExistsSync(filePath)
+      })
+
+    try {
+      expect(() =>
+        storage.updateRequest(id, { name: 'Must Not Move' }),
+      ).toThrow(
+        'REQUEST_FILE_MOVE_FAILED:source appeared after missing-source preflight',
+      )
+
+      expect(fs.readFileSync(sourcePath, 'utf8')).toBe('late source')
+      expect(fs.pathExistsSync(targetPath)).toBe(false)
+      expect(record).toEqual(recordBefore)
+      expect(indexEntry.filePath).toBe(originalPath)
+    }
+    finally {
+      existsSpy.mockRestore()
+    }
+  })
+
+  it('keeps record and index unchanged when a missing-source target appears', () => {
+    const paths = getHttpPaths(tempVaultPath)
+    const storage = createHttpRequestsStorage()
+    const { id } = storage.createRequest({ name: 'Late Target Source' })
+    const cache = getHttpRuntimeCache(paths)
+    const record = cache.requestById.get(id)!
+    const indexEntry = cache.state.requests.find(item => item.id === id)!
+    const sourcePath = path.join(paths.httpRoot, record.filePath)
+    const targetPath = path.join(paths.httpRoot, 'Late Target.md')
+    const originalPath = record.filePath
+    const recordBefore = { ...record }
+    const pathExistsSync = fs.pathExistsSync.bind(fs)
+    let targetChecks = 0
+
+    fs.removeSync(sourcePath)
+    const existsSpy = vi
+      .spyOn(fs, 'pathExistsSync')
+      .mockImplementation((filePath) => {
+        if (filePath === targetPath) {
+          targetChecks += 1
+          if (targetChecks === 2) {
+            fs.writeFileSync(targetPath, 'late target', 'utf8')
+            return true
+          }
+        }
+        return pathExistsSync(filePath)
+      })
+
+    try {
+      expect(() => storage.updateRequest(id, { name: 'Late Target' })).toThrow(
+        'REQUEST_FILE_MOVE_FAILED:target appeared after missing-source preflight',
+      )
+
+      expect(fs.pathExistsSync(sourcePath)).toBe(false)
+      expect(fs.readFileSync(targetPath, 'utf8')).toBe('late target')
+      expect(record).toEqual(recordBefore)
+      expect(indexEntry.filePath).toBe(originalPath)
+    }
+    finally {
+      existsSpy.mockRestore()
+    }
   })
 
   // Два ресинка: первый скан дозаполняет индекс метаданных, второй строит

--- a/src/main/storage/providers/markdown/http/storages/folders.ts
+++ b/src/main/storage/providers/markdown/http/storages/folders.ts
@@ -12,8 +12,13 @@ import type {
 } from '../runtime/types'
 import path from 'node:path'
 import fs from 'fs-extra'
+import { enqueueCloudDownload } from '../../cloudDownloads'
 import { normalizeFlag, normalizeNumber } from '../../runtime/normalizers'
 import { getVaultPath } from '../../runtime/paths'
+import {
+  getFileAvailability,
+  markAppWrittenFileAsLocal,
+} from '../../runtime/shared/cloudFiles'
 import {
   assertEntityFileWritable,
   throwCloudContentUnavailable,
@@ -47,6 +52,7 @@ import {
 import {
   ensureRequestDetailsLoaded,
   writeRequestFile,
+  writeVerifiedMovedLocalRequestFile,
 } from '../runtime/parser'
 import { getHttpPaths } from '../runtime/paths'
 import { saveHttpState } from '../runtime/state'
@@ -79,13 +85,15 @@ function getUniqueRootRequestPath(
   state: HttpState,
   name: string,
   currentFilePath: string,
+  reservedPaths?: Set<string>,
 ): string {
   const targetPath = `${name}.md`
   const targetAbsolutePath = path.join(httpRoot, targetPath)
   const currentAbsolutePath = path.join(httpRoot, currentFilePath)
 
   if (
-    !fs.pathExistsSync(targetAbsolutePath)
+    (!fs.pathExistsSync(targetAbsolutePath)
+      && !reservedPaths?.has(targetPath.toLowerCase()))
     || targetAbsolutePath.toLowerCase() === currentAbsolutePath.toLowerCase()
   ) {
     return targetPath
@@ -95,7 +103,10 @@ function getUniqueRootRequestPath(
     const candidatePath = `${name} ${suffix}.md`
     const candidateAbsolutePath = path.join(httpRoot, candidatePath)
 
-    if (!fs.pathExistsSync(candidateAbsolutePath)) {
+    if (
+      !fs.pathExistsSync(candidateAbsolutePath)
+      && !reservedPaths?.has(candidatePath.toLowerCase())
+    ) {
       return candidatePath
     }
   }
@@ -107,35 +118,45 @@ function moveRequestToTrash(
   httpRoot: string,
   state: HttpState,
   record: HttpRequestRecord,
+  nextFilePath: string,
+  sourceFileVerifiedLocal: boolean,
 ): void {
   const previousFilePath = record.filePath
-  const nextFilePath = getUniqueRootRequestPath(
-    httpRoot,
-    state,
-    record.name,
-    previousFilePath,
-  )
   const previousAbsolutePath = path.join(httpRoot, previousFilePath)
   const nextAbsolutePath = path.join(httpRoot, nextFilePath)
+
+  if (nextFilePath === previousFilePath) {
+    throw new Error('REQUEST_FILE_MOVE_FAILED:trash path did not change')
+  }
+
+  if (sourceFileVerifiedLocal) {
+    fs.moveSync(previousAbsolutePath, nextAbsolutePath, { overwrite: false })
+  }
+  else if (
+    fs.pathExistsSync(previousAbsolutePath)
+    || fs.pathExistsSync(nextAbsolutePath)
+  ) {
+    throw new Error(
+      'REQUEST_FILE_MOVE_FAILED:path appeared after missing-source preflight',
+    )
+  }
 
   record.folderId = null
   record.isDeleted = 1
   record.updatedAt = Date.now()
+  record.filePath = nextFilePath
 
-  if (nextFilePath !== previousFilePath) {
-    fs.ensureDirSync(path.dirname(nextAbsolutePath))
-    if (fs.pathExistsSync(previousAbsolutePath)) {
-      fs.moveSync(previousAbsolutePath, nextAbsolutePath, { overwrite: false })
-    }
-    record.filePath = nextFilePath
-
-    const indexEntry = state.requests.find(entry => entry.id === record.id)
-    if (indexEntry) {
-      indexEntry.filePath = nextFilePath
-    }
+  const indexEntry = state.requests.find(entry => entry.id === record.id)
+  if (indexEntry) {
+    indexEntry.filePath = nextFilePath
   }
 
-  writeRequestFile(httpRoot, record)
+  if (sourceFileVerifiedLocal) {
+    writeVerifiedMovedLocalRequestFile(httpRoot, record)
+  }
+  else {
+    writeRequestFile(httpRoot, record)
+  }
 }
 
 export function createHttpFoldersStorage(): HttpFoldersStorage {
@@ -308,6 +329,32 @@ export function createHttpFoldersStorage(): HttpFoldersStorage {
             oldPath,
           )
 
+          const verifiedLocalRequestIds = new Set<number>()
+          for (const record of cache.requestById.values()) {
+            const nextRequestPath = replaceSubtreePathPrefix(
+              record.filePath,
+              oldPath,
+              newPath,
+            )
+            if (nextRequestPath === record.filePath) {
+              continue
+            }
+
+            const absolutePath = path.join(paths.httpRoot, record.filePath)
+            const availability = getFileAvailability(absolutePath)
+            if (
+              record.pendingCloudDownload
+              || availability.isCloudPlaceholder
+            ) {
+              record.pendingCloudDownload = true
+              continue
+            }
+
+            if (availability.exists) {
+              verifiedLocalRequestIds.add(record.id)
+            }
+          }
+
           moveFolderDirectoryOnDisk(paths.httpRoot, oldPath, newPath)
 
           updateChildEntityPaths({
@@ -318,6 +365,13 @@ export function createHttpFoldersStorage(): HttpFoldersStorage {
               const indexEntry = state.requests.find(r => r.id === record.id)
               if (indexEntry) {
                 indexEntry.filePath = nextPath
+              }
+              const nextAbsolutePath = path.join(paths.httpRoot, nextPath)
+              if (verifiedLocalRequestIds.has(record.id)) {
+                markAppWrittenFileAsLocal(nextAbsolutePath)
+              }
+              else if (record.pendingCloudDownload) {
+                enqueueCloudDownload(nextAbsolutePath)
               }
             },
           })
@@ -365,10 +419,10 @@ export function createHttpFoldersStorage(): HttpFoldersStorage {
       // Trash-маркер запроса — frontmatter isDeleted, а не путь: перенос
       // недокачанного файла без перезаписи frontmatter «воскресил» бы запрос
       // после докачки. Preflight выполняется до первой мутации в две фазы:
-      // сначала eager-дочитка body/description всех записей, затем свежий
-      // stat всех файлов (флаг pendingCloudDownload мог устареть после
-      // eviction) — так окно между проверкой и мутацией не растягивается на
-      // гидрацию соседей.
+      // сначала eager-дочитка body/description всех записей, затем свежая
+      // availability-проверка всех файлов (флаг pendingCloudDownload мог
+      // устареть после eviction) — так окно между проверкой и мутацией не
+      // растягивается на гидрацию соседей.
       const affectedRecords = [...cache.requestById.values()].filter(
         record =>
           record.folderId !== null && descendantIds.has(record.folderId),
@@ -396,17 +450,49 @@ export function createHttpFoldersStorage(): HttpFoldersStorage {
         new Set(affectedRecords.map(record => record.filePath)),
       )
 
+      const reservedTargetPaths = new Set<string>()
+      const trashPlans: {
+        nextFilePath: string
+        record: HttpRequestRecord
+        sourceFileVerifiedLocal: boolean
+      }[] = []
       for (const record of affectedRecords) {
-        assertEntityFileWritable(
-          path.join(paths.httpRoot, record.filePath),
-          record,
+        const absolutePath = path.join(paths.httpRoot, record.filePath)
+        assertEntityFileWritable(absolutePath, record)
+        const availability = getFileAvailability(absolutePath)
+        if (
+          availability.exists
+          && (!availability.stats || !availability.stats.isFile())
+        ) {
+          throw new Error(
+            'REQUEST_FILE_MOVE_FAILED:source is not a regular file',
+          )
+        }
+
+        const nextFilePath = getUniqueRootRequestPath(
+          paths.httpRoot,
+          state,
+          record.name,
+          record.filePath,
+          reservedTargetPaths,
         )
+        reservedTargetPaths.add(nextFilePath.toLowerCase())
+        trashPlans.push({
+          nextFilePath,
+          record,
+          sourceFileVerifiedLocal:
+            availability.exists && !availability.isCloudPlaceholder,
+        })
       }
 
-      for (const record of cache.requestById.values()) {
-        if (record.folderId !== null && descendantIds.has(record.folderId)) {
-          moveRequestToTrash(paths.httpRoot, state, record)
-        }
+      for (const plan of trashPlans) {
+        moveRequestToTrash(
+          paths.httpRoot,
+          state,
+          plan.record,
+          plan.nextFilePath,
+          plan.sourceFileVerifiedLocal,
+        )
       }
 
       removeFolderPathsFromDisk(paths.httpRoot, folderPathsToDelete, {

--- a/src/main/storage/providers/markdown/http/storages/requests.ts
+++ b/src/main/storage/providers/markdown/http/storages/requests.ts
@@ -15,6 +15,7 @@ import fs from 'fs-extra'
 import { prioritizeCloudDownload } from '../../cloudDownloads'
 import { normalizeFlag } from '../../runtime/normalizers'
 import { getVaultPath } from '../../runtime/paths'
+import { getFileAvailability } from '../../runtime/shared/cloudFiles'
 import {
   assertEntityFileWritable,
   markEntityPendingIfEvicted,
@@ -32,6 +33,7 @@ import {
 import {
   ensureRequestDetailsLoaded,
   writeRequestFile,
+  writeVerifiedMovedLocalRequestFile,
 } from '../runtime/parser'
 import { getHttpPaths } from '../runtime/paths'
 import { saveHttpState } from '../runtime/state'
@@ -77,19 +79,20 @@ function moveRequestFile(
   httpRoot: string,
   oldFilePath: string,
   newFilePath: string,
-): void {
+): boolean {
   if (oldFilePath === newFilePath) {
-    return
+    return false
   }
 
   const oldAbsolutePath = path.join(httpRoot, oldFilePath)
   if (!fs.pathExistsSync(oldAbsolutePath)) {
-    return
+    return false
   }
 
   const newAbsolutePath = path.join(httpRoot, newFilePath)
   fs.ensureDirSync(path.dirname(newAbsolutePath))
   fs.moveSync(oldAbsolutePath, newAbsolutePath, { overwrite: false })
+  return true
 }
 
 function getUniqueRequestFilePath(
@@ -337,6 +340,9 @@ export function createHttpRequestsStorage(): HttpRequestsStorage {
       const previousFilePath = record.filePath
       const previousName = record.name
       const previousFolderId = record.folderId
+      let moved = false
+      let resolvedPath = previousFilePath
+      let sourceFileVerifiedLocal = false
 
       const nextFolderId
         = input.folderId !== undefined
@@ -376,8 +382,60 @@ export function createHttpRequestsStorage(): HttpRequestsStorage {
         )
       }
 
+      if (previousName !== nextName || previousFolderId !== nextFolderId) {
+        const targetPath = buildRequestFilePath(state, nextFolderId, nextName)
+        resolvedPath = getUniqueRequestFilePath(
+          paths.httpRoot,
+          targetPath,
+          previousFilePath,
+        )
+      }
+
+      if (resolvedPath !== previousFilePath) {
+        const previousAbsolutePath = path.join(
+          paths.httpRoot,
+          previousFilePath,
+        )
+        assertEntityFileWritable(previousAbsolutePath, record)
+        const sourceAvailability = getFileAvailability(previousAbsolutePath)
+        sourceFileVerifiedLocal
+          = sourceAvailability.exists && !sourceAvailability.isCloudPlaceholder
+
+        if (sourceFileVerifiedLocal) {
+          moved = moveRequestFile(
+            paths.httpRoot,
+            previousFilePath,
+            resolvedPath,
+          )
+          if (!moved) {
+            throw new Error(
+              'REQUEST_FILE_MOVE_FAILED:verified source disappeared before move',
+            )
+          }
+        }
+        else {
+          const resolvedAbsolutePath = path.join(paths.httpRoot, resolvedPath)
+          if (fs.pathExistsSync(previousAbsolutePath)) {
+            throw new Error(
+              'REQUEST_FILE_MOVE_FAILED:source appeared after missing-source preflight',
+            )
+          }
+          if (fs.pathExistsSync(resolvedAbsolutePath)) {
+            throw new Error(
+              'REQUEST_FILE_MOVE_FAILED:target appeared after missing-source preflight',
+            )
+          }
+        }
+      }
+
       record.name = nextName
       record.folderId = nextFolderId
+      if (
+        resolvedPath !== previousFilePath
+        && path.posix.basename(resolvedPath, '.md') !== record.name
+      ) {
+        record.name = path.posix.basename(resolvedPath, '.md')
+      }
       if (input.isDeleted !== undefined)
         record.isDeleted = normalizeFlag(input.isDeleted)
       if (input.isFavorites !== undefined)
@@ -403,36 +461,21 @@ export function createHttpRequestsStorage(): HttpRequestsStorage {
 
       record.updatedAt = Date.now()
 
-      if (
-        previousName !== record.name
-        || previousFolderId !== record.folderId
-      ) {
-        const targetPath = buildRequestFilePath(
-          state,
-          record.folderId,
-          record.name,
-        )
-        const resolvedPath = getUniqueRequestFilePath(
-          paths.httpRoot,
-          targetPath,
-          previousFilePath,
-        )
-        if (resolvedPath !== targetPath) {
-          record.name = path.posix.basename(resolvedPath, '.md')
-        }
+      if (resolvedPath !== previousFilePath) {
+        record.filePath = resolvedPath
 
-        if (resolvedPath !== previousFilePath) {
-          moveRequestFile(paths.httpRoot, previousFilePath, resolvedPath)
-          record.filePath = resolvedPath
-
-          const indexEntry = state.requests.find(entry => entry.id === id)
-          if (indexEntry) {
-            indexEntry.filePath = resolvedPath
-          }
+        const indexEntry = state.requests.find(entry => entry.id === id)
+        if (indexEntry) {
+          indexEntry.filePath = resolvedPath
         }
       }
 
-      writeRequestFile(paths.httpRoot, record)
+      if (moved && sourceFileVerifiedLocal) {
+        writeVerifiedMovedLocalRequestFile(paths.httpRoot, record)
+      }
+      else {
+        writeRequestFile(paths.httpRoot, record)
+      }
       saveHttpState(paths, state)
 
       return { invalidInput: false, notFound: false }


### PR DESCRIPTION
## Summary

- Treat app-written HTTP request files with zero allocated blocks as local after writes and verified moves.
- Preserve cloud placeholders by blocking unsafe writes and re-queuing downloads after folder moves.
- Cover request and folder rename, trash, missing-file, and race cases.

## Testing

- `pnpm exec vitest run src/main/storage/providers/markdown/http/storages/__tests__/requests.test.ts src/main/storage/providers/markdown/http/storages/__tests__/folders.test.ts` (22 passed)
- `pnpm exec eslint` on the five changed HTTP files
- `git diff --check`