### PR TITLE
fix(storage): preserve local zero-block folder metadata

### DIFF
--- a/src/main/storage/providers/markdown/notes/runtime/parser.ts
+++ b/src/main/storage/providers/markdown/notes/runtime/parser.ts
@@ -11,7 +11,10 @@ import {
   prioritizeCloudDownload,
 } from '../../cloudDownloads'
 import { rememberAppFileChange } from '../../runtime/shared/appChanges'
-import { getFileAvailability } from '../../runtime/shared/cloudFiles'
+import {
+  getFileAvailability,
+  markAppWrittenFileAsLocal,
+} from '../../runtime/shared/cloudFiles'
 import {
   isYamlFileCloudUnavailable,
   readYamlObjectFile,
@@ -90,5 +93,6 @@ export function writeNotesFolderMetadataFile(
 
   fs.ensureDirSync(folderAbsPath)
   fs.writeFileSync(metaPath, nextContent, 'utf8')
+  markAppWrittenFileAsLocal(metaPath)
   rememberAppFileChange(metaPath)
 }

--- a/src/main/storage/providers/markdown/notes/storages/__tests__/folders.test.ts
+++ b/src/main/storage/providers/markdown/notes/storages/__tests__/folders.test.ts
@@ -3,12 +3,44 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { enqueueCloudDownload } from '../../../cloudDownloads'
+import {
+  getFileAvailability,
+  markAppWrittenFileAsLocal,
+  resetCloudFileExemptions,
+  setDatalessProbeForTests,
+} from '../../../runtime/shared/cloudFiles'
 import { ensureNotesStateFile } from '../../runtime/state'
 import { resetNotesRuntimeCache } from '../../runtime/sync'
 import { createNotesFoldersStorage } from '../folders'
 import { createNotesNotesStorage } from '../notes'
 
 let tempVaultPath = ''
+
+function makeSparsePlaceholder(absolutePath: string, size = 4096): void {
+  fs.removeSync(absolutePath)
+  const fd = fs.openSync(absolutePath, 'w')
+  fs.ftruncateSync(fd, size)
+  fs.closeSync(fd)
+}
+
+function mockFolderMetadataAsZeroBlocks() {
+  const statSync = fs.statSync.bind(fs)
+
+  return vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+    const stats = statSync(filePath)
+
+    if (
+      typeof filePath === 'string'
+      && filePath.endsWith('.meta.yaml')
+      && stats.size > 0
+    ) {
+      return Object.assign(stats, { blocks: 0 })
+    }
+
+    return stats
+  })
+}
 
 vi.mock('electron-store', () => {
   class MockStore {
@@ -60,6 +92,11 @@ vi.mock('electron', () => ({
   },
 }))
 
+vi.mock('../../../cloudDownloads', () => ({
+  enqueueCloudDownload: vi.fn(),
+  prioritizeCloudDownload: vi.fn(),
+}))
+
 vi.mock('../../../../../../store', () => ({
   store: {
     preferences: {
@@ -94,6 +131,10 @@ describe('folders storage validations', () => {
   })
 
   afterEach(() => {
+    setDatalessProbeForTests(null)
+    resetCloudFileExemptions()
+    resetNotesRuntimeCache()
+
     if (tempVaultPath) {
       fs.removeSync(tempVaultPath)
     }
@@ -214,5 +255,102 @@ describe('folders storage validations', () => {
     folders.updateFolder(folderA.id, { name: 'Renamed' })
 
     expect(notes.getNoteById(linker.id)?.content).toBe('See [[Foo]] here')
+  })
+
+  it('keeps resident zero-block subtree metadata local after parent move', () => {
+    const notesRoot = path.join(tempVaultPath, 'notes')
+    setDatalessProbeForTests(() => true)
+    const statSpy = mockFolderMetadataAsZeroBlocks()
+
+    try {
+      const storage = createNotesFoldersStorage()
+      const destination = storage.createFolder({ name: 'Destination' })
+      const parent = storage.createFolder({ name: 'Parent' })
+      storage.createFolder({ name: 'Child', parentId: parent.id })
+      const beforeMetadata = fs.readFileSync(
+        path.join(notesRoot, 'Parent', '.meta.yaml'),
+        'utf8',
+      )
+      const previousUpdatedAt = storage
+        .getFolders()
+        .find(folder => folder.id === parent.id)!.updatedAt
+      const nowSpy = vi
+        .spyOn(Date, 'now')
+        .mockReturnValue(previousUpdatedAt + 1)
+
+      try {
+        storage.updateFolder(parent.id, { parentId: destination.id })
+      }
+      finally {
+        nowSpy.mockRestore()
+      }
+
+      const parentMetaPath = path.join(
+        notesRoot,
+        'Destination',
+        'Parent',
+        '.meta.yaml',
+      )
+      const childMetaPath = path.join(
+        notesRoot,
+        'Destination',
+        'Parent',
+        'Child',
+        '.meta.yaml',
+      )
+
+      expect(getFileAvailability(parentMetaPath).isCloudPlaceholder).toBe(
+        false,
+      )
+      expect(getFileAvailability(childMetaPath).isCloudPlaceholder).toBe(false)
+      expect(fs.readFileSync(parentMetaPath, 'utf8')).not.toBe(beforeMetadata)
+    }
+    finally {
+      statSpy.mockRestore()
+    }
+  })
+
+  it('does not exempt or overwrite descendant metadata placeholder after parent move', () => {
+    const notesRoot = path.join(tempVaultPath, 'notes')
+    setDatalessProbeForTests(() => true)
+    const statSpy = mockFolderMetadataAsZeroBlocks()
+
+    try {
+      const storage = createNotesFoldersStorage()
+      const destination = storage.createFolder({ name: 'Destination' })
+      const parent = storage.createFolder({ name: 'Parent' })
+      storage.createFolder({ name: 'Child', parentId: parent.id })
+      const parentMetaPath = path.join(notesRoot, 'Parent', '.meta.yaml')
+      const childSourcePath = path.join(
+        notesRoot,
+        'Parent',
+        'Child',
+        '.meta.yaml',
+      )
+
+      makeSparsePlaceholder(childSourcePath)
+      resetCloudFileExemptions()
+      markAppWrittenFileAsLocal(parentMetaPath)
+      const placeholderBefore = fs.readFileSync(childSourcePath)
+      const childTargetPath = path.join(
+        notesRoot,
+        'Destination',
+        'Parent',
+        'Child',
+        '.meta.yaml',
+      )
+      vi.mocked(enqueueCloudDownload).mockClear()
+
+      storage.updateFolder(parent.id, { parentId: destination.id })
+
+      expect(fs.readFileSync(childTargetPath)).toEqual(placeholderBefore)
+      expect(getFileAvailability(childTargetPath).isCloudPlaceholder).toBe(
+        true,
+      )
+      expect(enqueueCloudDownload).toHaveBeenCalledWith(childTargetPath)
+    }
+    finally {
+      statSpy.mockRestore()
+    }
   })
 })

--- a/src/main/storage/providers/markdown/notes/storages/folders.ts
+++ b/src/main/storage/providers/markdown/notes/storages/folders.ts
@@ -9,6 +9,10 @@ import { scheduleDockBadgeRefresh } from '../../../../../dockBadge'
 import { normalizeFlag, normalizeNumber } from '../../runtime/normalizers'
 import { getVaultPath } from '../../runtime/paths'
 import {
+  getFileAvailability,
+  markAppWrittenFileAsLocal,
+} from '../../runtime/shared/cloudFiles'
+import {
   assertEntityFileWritable,
   throwCloudContentUnavailable,
 } from '../../runtime/shared/cloudGuards'
@@ -38,6 +42,7 @@ import { rewriteBacklinksAfterFolderUpdate } from '../runtime/backlinks'
 import {
   getNotesPaths,
   META_DIR_NAME,
+  META_FILE_NAME,
   NOTES_RESERVED_ROOT_NAMES,
 } from '../runtime/constants'
 import { ensureNoteContentLoaded, persistNote } from '../runtime/notes'
@@ -248,7 +253,40 @@ export function createNotesFoldersStorage(): NotesFoldersStorage {
             oldPath,
           )
 
+          const affectedFolderIds = collectDescendantIds(state.folders, id)
+          affectedFolderIds.add(id)
+          const localMetadataTargetPaths: string[] = []
+
+          for (const folderId of affectedFolderIds) {
+            const oldFolderPath = oldFolderPathMap.get(folderId)
+            const newFolderPath = newFolderPathMap.get(folderId)
+            if (
+              !oldFolderPath
+              || !newFolderPath
+              || oldFolderPath === newFolderPath
+            ) {
+              continue
+            }
+
+            const sourceMetadataPath = path.join(
+              paths.notesRoot,
+              oldFolderPath,
+              META_FILE_NAME,
+            )
+            const sourceAvailability = getFileAvailability(sourceMetadataPath)
+            if (
+              sourceAvailability.exists
+              && !sourceAvailability.isCloudPlaceholder
+            ) {
+              localMetadataTargetPaths.push(
+                path.join(paths.notesRoot, newFolderPath, META_FILE_NAME),
+              )
+            }
+          }
+
           moveFolderDirectoryOnDisk(paths.notesRoot, oldPath, newPath)
+
+          localMetadataTargetPaths.forEach(markAppWrittenFileAsLocal)
 
           updateChildEntityPaths({
             entries: notes,

--- a/src/main/storage/providers/markdown/runtime/__tests__/parser.test.ts
+++ b/src/main/storage/providers/markdown/runtime/__tests__/parser.test.ts
@@ -1,11 +1,25 @@
 import type { MarkdownSnippet } from '../types'
-import { describe, expect, it } from 'vitest'
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'fs-extra'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   parseBodyFragments,
   parseBodyFragmentsWithMetadata,
+  readFolderMetadata,
   serializeSnippet,
   splitFrontmatter,
 } from '../parser'
+import {
+  getFileAvailability,
+  resetCloudFileExemptions,
+  setDatalessProbeForTests,
+} from '../shared/cloudFiles'
+
+afterEach(() => {
+  setDatalessProbeForTests(null)
+  resetCloudFileExemptions()
+})
 
 function createSnippet(value: string): MarkdownSnippet {
   return {
@@ -116,5 +130,49 @@ describe('legacy snippet fence recovery', () => {
       ].join('\n'),
     )
     expect(result.fragments[1].value).toBe('console.log("second")')
+  })
+})
+
+describe('legacy folder metadata migration', () => {
+  it('marks a zero-block migrated metadata file as local', () => {
+    const vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'parser-legacy-'))
+    const folderPath = path.join(vaultPath, 'Legacy')
+    const legacyPath = path.join(folderPath, '.masscode-folder.yml')
+    const metaPath = path.join(folderPath, '.meta.yaml')
+    fs.ensureDirSync(folderPath)
+    fs.writeFileSync(legacyPath, 'masscode_id: 7\nname: Legacy\n', 'utf8')
+
+    const statSync = fs.statSync.bind(fs)
+    const statSpy = vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+      const stats = statSync(filePath)
+
+      if (filePath === metaPath && stats.size > 0) {
+        return Object.assign(stats, { blocks: 0 })
+      }
+
+      return stats
+    })
+    setDatalessProbeForTests(() => true)
+
+    try {
+      expect(
+        readFolderMetadata(
+          {
+            inboxDirPath: path.join(vaultPath, '.masscode', 'inbox'),
+            metaDirPath: path.join(vaultPath, '.masscode'),
+            statePath: path.join(vaultPath, '.masscode', 'state.json'),
+            trashDirPath: path.join(vaultPath, '.masscode', 'trash'),
+            vaultPath,
+          },
+          'Legacy',
+        ),
+      ).toMatchObject({ id: 7, name: 'Legacy' })
+      expect(fs.pathExistsSync(legacyPath)).toBe(false)
+      expect(getFileAvailability(metaPath).isCloudPlaceholder).toBe(false)
+    }
+    finally {
+      statSpy.mockRestore()
+      fs.removeSync(vaultPath)
+    }
   })
 })

--- a/src/main/storage/providers/markdown/runtime/parser.ts
+++ b/src/main/storage/providers/markdown/runtime/parser.ts
@@ -20,7 +20,10 @@ import {
   NEW_LINE_SPLIT_RE,
 } from './constants'
 import { rememberAppFileChange } from './shared/appChanges'
-import { getFileAvailability } from './shared/cloudFiles'
+import {
+  getFileAvailability,
+  markAppWrittenFileAsLocal,
+} from './shared/cloudFiles'
 import {
   isYamlFileCloudUnavailable,
   readYamlObjectFile,
@@ -69,6 +72,7 @@ export function readFolderMetadata(
 
   try {
     writeYamlObjectFile(metaPath, migrated as Record<string, unknown>)
+    markAppWrittenFileAsLocal(metaPath)
     fs.removeSync(legacyPath)
     rememberAppFileChange(metaPath)
     rememberAppFileChange(legacyPath)
@@ -145,6 +149,7 @@ export function writeFolderMetadataFile(
 
   fs.ensureDirSync(folderAbsPath)
   fs.writeFileSync(metaPath, nextContent, 'utf8')
+  markAppWrittenFileAsLocal(metaPath)
   rememberAppFileChange(metaPath)
 
   // Clean up legacy file if it exists

--- a/src/main/storage/providers/markdown/storages/__tests__/folders.test.ts
+++ b/src/main/storage/providers/markdown/storages/__tests__/folders.test.ts
@@ -3,12 +3,44 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { enqueueCloudDownload } from '../../cloudDownloads'
 import { getPaths } from '../../runtime/paths'
+import {
+  getFileAvailability,
+  markAppWrittenFileAsLocal,
+  resetCloudFileExemptions,
+  setDatalessProbeForTests,
+} from '../../runtime/shared/cloudFiles'
 import { ensureStateFile } from '../../runtime/state'
 import { resetRuntimeCache } from '../../runtime/sync'
 import { createFoldersStorage } from '../folders'
 
 let tempVaultPath = ''
+
+function makeSparsePlaceholder(absolutePath: string, size = 4096): void {
+  fs.removeSync(absolutePath)
+  const fd = fs.openSync(absolutePath, 'w')
+  fs.ftruncateSync(fd, size)
+  fs.closeSync(fd)
+}
+
+function mockFolderMetadataAsZeroBlocks() {
+  const statSync = fs.statSync.bind(fs)
+
+  return vi.spyOn(fs, 'statSync').mockImplementation((filePath) => {
+    const stats = statSync(filePath)
+
+    if (
+      typeof filePath === 'string'
+      && filePath.endsWith('.meta.yaml')
+      && stats.size > 0
+    ) {
+      return Object.assign(stats, { blocks: 0 })
+    }
+
+    return stats
+  })
+}
 
 vi.mock('electron-store', () => {
   class MockStore {
@@ -60,6 +92,11 @@ vi.mock('electron', () => ({
   },
 }))
 
+vi.mock('../../cloudDownloads', () => ({
+  enqueueCloudDownload: vi.fn(),
+  prioritizeCloudDownload: vi.fn(),
+}))
+
 vi.mock('../../../../../store', () => ({
   store: {
     preferences: {
@@ -84,6 +121,8 @@ describe('code folders storage validations', () => {
   })
 
   afterEach(() => {
+    setDatalessProbeForTests(null)
+    resetCloudFileExemptions()
     resetRuntimeCache()
 
     if (tempVaultPath) {
@@ -135,5 +174,78 @@ describe('code folders storage validations', () => {
     expect(() => storage.createFolder({ name: 'math' })).toThrow(
       'RESERVED_NAME',
     )
+  })
+
+  it('keeps resident zero-block subtree metadata local after parent rename', () => {
+    const paths = getPaths(tempVaultPath)
+    setDatalessProbeForTests(() => true)
+    const statSpy = mockFolderMetadataAsZeroBlocks()
+
+    try {
+      const storage = createFoldersStorage()
+      const parent = storage.createFolder({ name: 'Before' })
+      storage.createFolder({ name: 'Child', parentId: parent.id })
+
+      storage.updateFolder(parent.id, { name: 'After' })
+
+      const parentMetaPath = path.join(paths.vaultPath, 'After', '.meta.yaml')
+      const childMetaPath = path.join(
+        paths.vaultPath,
+        'After',
+        'Child',
+        '.meta.yaml',
+      )
+
+      expect(getFileAvailability(parentMetaPath).isCloudPlaceholder).toBe(
+        false,
+      )
+      expect(getFileAvailability(childMetaPath).isCloudPlaceholder).toBe(false)
+      expect(fs.readFileSync(parentMetaPath, 'utf8')).toContain('name: After')
+    }
+    finally {
+      statSpy.mockRestore()
+    }
+  })
+
+  it('does not exempt or overwrite a moved metadata placeholder', () => {
+    const paths = getPaths(tempVaultPath)
+    setDatalessProbeForTests(() => true)
+    const statSpy = mockFolderMetadataAsZeroBlocks()
+
+    try {
+      const storage = createFoldersStorage()
+      const parent = storage.createFolder({ name: 'Before' })
+      storage.createFolder({ name: 'Child', parentId: parent.id })
+      const parentMetaPath = path.join(paths.vaultPath, 'Before', '.meta.yaml')
+      const childSourcePath = path.join(
+        paths.vaultPath,
+        'Before',
+        'Child',
+        '.meta.yaml',
+      )
+
+      makeSparsePlaceholder(childSourcePath)
+      resetCloudFileExemptions()
+      markAppWrittenFileAsLocal(parentMetaPath)
+      const placeholderBefore = fs.readFileSync(childSourcePath)
+      const childTargetPath = path.join(
+        paths.vaultPath,
+        'After',
+        'Child',
+        '.meta.yaml',
+      )
+      vi.mocked(enqueueCloudDownload).mockClear()
+
+      storage.updateFolder(parent.id, { name: 'After' })
+
+      expect(fs.readFileSync(childTargetPath)).toEqual(placeholderBefore)
+      expect(getFileAvailability(childTargetPath).isCloudPlaceholder).toBe(
+        true,
+      )
+      expect(enqueueCloudDownload).toHaveBeenCalledWith(childTargetPath)
+    }
+    finally {
+      statSpy.mockRestore()
+    }
   })
 })

--- a/src/main/storage/providers/markdown/storages/folders.ts
+++ b/src/main/storage/providers/markdown/storages/folders.ts
@@ -16,6 +16,7 @@ import {
   getRuntimeCache,
   getVaultPath,
   isCodeVaultDiskReady,
+  META_FILE_NAME,
   normalizeDirectoryPath,
   normalizeFlag,
   persistSnippet,
@@ -25,7 +26,10 @@ import {
   throwStorageError,
   validateEntryName,
 } from '../runtime'
-import { getFileAvailability } from '../runtime/shared/cloudFiles'
+import {
+  getFileAvailability,
+  markAppWrittenFileAsLocal,
+} from '../runtime/shared/cloudFiles'
 import {
   applyFolderParentAndOrder,
   assertFolderMoveTargetValid,
@@ -211,14 +215,40 @@ export function createFoldersStorage(): FoldersStorage {
           oldFolderPath,
         )
 
+        const affectedFolderIds = collectDescendantIds(state.folders, id)
+        affectedFolderIds.add(id)
+        const localMetadataTargetPaths: string[] = []
+
+        for (const folderId of affectedFolderIds) {
+          const oldPath = oldFolderPathMap.get(folderId)
+          const newPath = newFolderPathMap.get(folderId)
+          if (!oldPath || !newPath || oldPath === newPath) {
+            continue
+          }
+
+          const sourceMetadataPath = path.join(
+            paths.vaultPath,
+            oldPath,
+            META_FILE_NAME,
+          )
+          const sourceAvailability = getFileAvailability(sourceMetadataPath)
+          if (
+            sourceAvailability.exists
+            && !sourceAvailability.isCloudPlaceholder
+          ) {
+            localMetadataTargetPaths.push(
+              path.join(paths.vaultPath, newPath, META_FILE_NAME),
+            )
+          }
+        }
+
         moveFolderDirectoryOnDisk(
           paths.vaultPath,
           oldFolderPath,
           newFolderPath,
         )
 
-        const affectedFolderIds = collectDescendantIds(state.folders, id)
-        affectedFolderIds.add(id)
+        localMetadataTargetPaths.forEach(markAppWrittenFileAsLocal)
 
         updateChildEntityPaths({
           entries: snippets,


### PR DESCRIPTION
## Summary

- Preserve the local availability exemption for resident folder metadata written, migrated, or moved by the app.
- Apply move handling to both Code and Notes folder subtrees.
- Keep genuine cloud placeholders protected and queue their download at the moved path instead of overwriting them.

## Testing

- `pnpm exec vitest run src/main/storage/providers/markdown/runtime/__tests__/parser.test.ts src/main/storage/providers/markdown/storages/__tests__/folders.test.ts src/main/storage/providers/markdown/notes/storages/__tests__/folders.test.ts` (19 passed)
- `pnpm exec eslint` on the seven changed files
- `git diff --check`