### PR TITLE
fix(notes): support parenthesized ordered list markers

### DIFF
--- a/src/renderer/components/notes/cm-extensions/__tests__/listLineIndent.test.ts
+++ b/src/renderer/components/notes/cm-extensions/__tests__/listLineIndent.test.ts
@@ -56,10 +56,15 @@ describe('parseListPrefix', () => {
     expect(parseListPrefix('1. item')?.[1]).toBe('1. ')
     expect(parseListPrefix('10. item')?.[1]).toBe('10. ')
     expect(parseListPrefix('123. item')?.[1]).toBe('123. ')
+    expect(parseListPrefix('1) item')?.[1]).toBe('1) ')
+    expect(parseListPrefix('10) item')?.[1]).toBe('10) ')
+    expect(parseListPrefix('123) item')?.[1]).toBe('123) ')
   })
 
   it('matches nested ordered list markers', () => {
     expect(parseListPrefix('  1. item')?.[1]).toBe('  1. ')
+    expect(parseListPrefix('  1) item')?.[1]).toBe('  1) ')
+    expect(parseListPrefix('    10) item')?.[1]).toBe('    10) ')
   })
 
   it('matches task markers', () => {
@@ -108,6 +113,16 @@ describe('getListContinuationLineNumbers', () => {
 
   it('keeps direct indented continuation lines in the list item', () => {
     const doc = ['- item', '  continuation'].join('\n')
+    const view = createViewLike(doc)
+    const range = getFirstListItemRange(view)
+
+    expect(getListContinuationLineNumbers(view, range.from, range.to)).toEqual([
+      2,
+    ])
+  })
+
+  it('keeps continuation lines for ordered list markers with a parenthesis', () => {
+    const doc = ['1) item', '   continuation'].join('\n')
     const view = createViewLike(doc)
     const range = getFirstListItemRange(view)
 

--- a/src/renderer/components/notes/cm-extensions/listLineIndent.ts
+++ b/src/renderer/components/notes/cm-extensions/listLineIndent.ts
@@ -8,7 +8,7 @@ import { getRevealSelection, revealSelectionChanged } from './revealSelection'
 const BASE_INDENT_PX = 14
 const CHECKBOX_WIDGET_PX = 24
 
-const LIST_PREFIX_RE = /^(\s*(?:[-*+]|\d+\.)\s)(?:(\[[ x]\])\s)?/i
+const LIST_PREFIX_RE = /^(\s*(?:[-*+]|\d+[.)])\s)(?:(\[[ x]\])\s)?/i
 
 export function parseListPrefix(text: string) {
   return text.match(LIST_PREFIX_RE)


### PR DESCRIPTION
## Summary

- Recognize parenthesized ordered list markers when calculating note-editor list indentation.
- Add coverage for single-digit, multi-digit, nested, and continuation-line parenthesized markers.

## Tests

- Scoped ESLint
- listLineIndent tests (12 passed)