### PR TITLE
fix(notes): use CRLF when copying notes on Windows

### DIFF
--- a/src/renderer/components/notes/NotesEditor.vue
+++ b/src/renderer/components/notes/NotesEditor.vue
@@ -12,6 +12,7 @@ import {
   useTheme,
 } from '@/composables'
 import { i18n, ipc } from '@/electron'
+import { isWindows } from '@/utils'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { indentUnit } from '@codemirror/language'
@@ -25,6 +26,7 @@ import {
   placeholder,
 } from '@codemirror/view'
 import { GFM, type MarkdownConfig } from '@lezer/markdown'
+import { createClipboardOutput } from './cm-extensions/clipboardOutput'
 import {
   clearInlineFormatting,
   getHeadingLevel,
@@ -224,6 +226,7 @@ function createEditorState(doc: string): EditorState {
       ? presentationTheme
       : createNotesEditTheme(raw, notesSettings),
     EditorView.lineWrapping,
+    createClipboardOutput(isWindows),
     history(),
     Prec.highest(
       keymap.of(editable ? createListIndent({ indent: notesIndentUnit }) : []),

--- a/src/renderer/components/notes/cm-extensions/__tests__/clipboardOutput.test.ts
+++ b/src/renderer/components/notes/cm-extensions/__tests__/clipboardOutput.test.ts
@@ -1,0 +1,36 @@
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { describe, expect, it } from 'vitest'
+import { createClipboardOutput } from '../clipboardOutput'
+
+function filterClipboardOutput(text: string, isWindows: boolean) {
+  const state = EditorState.create({
+    extensions: [createClipboardOutput(isWindows)],
+  })
+
+  return state
+    .facet(EditorView.clipboardOutputFilter)
+    .reduce((output, filter) => filter(output, state), text)
+}
+
+describe('clipboard output', () => {
+  it('converts LF line endings to CRLF on Windows', () => {
+    expect(filterClipboardOutput('first\nsecond\nthird', true)).toBe(
+      'first\r\nsecond\r\nthird',
+    )
+  })
+
+  it('does not duplicate CR in existing CRLF line endings on Windows', () => {
+    expect(filterClipboardOutput('first\r\nsecond', true)).toBe(
+      'first\r\nsecond',
+    )
+  })
+
+  it('leaves line endings unchanged on macOS and Linux', () => {
+    expect(filterClipboardOutput('first\nsecond', false)).toBe('first\nsecond')
+  })
+
+  it('leaves text without line endings unchanged', () => {
+    expect(filterClipboardOutput('single line', true)).toBe('single line')
+  })
+})

--- a/src/renderer/components/notes/cm-extensions/clipboardOutput.ts
+++ b/src/renderer/components/notes/cm-extensions/clipboardOutput.ts
@@ -1,0 +1,7 @@
+import { EditorView } from '@codemirror/view'
+
+export function createClipboardOutput(isWindows: boolean) {
+  return EditorView.clipboardOutputFilter.of(text =>
+    isWindows ? text.replace(/\r?\n/g, '\r\n') : text,
+  )
+}

--- a/src/renderer/utils/index.ts
+++ b/src/renderer/utils/index.ts
@@ -2,6 +2,7 @@ import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
 export const isMac = navigator.userAgent.toLowerCase().includes('mac')
+export const isWindows = navigator.userAgent.toLowerCase().includes('windows')
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))


### PR DESCRIPTION
Closes #893

Normalize copied note line endings to CRLF on Windows.