### PR TITLE
fix(ci): restore release build compatibility

### DIFF
--- a/src/main/__tests__/mainLifecycle.test.ts
+++ b/src/main/__tests__/mainLifecycle.test.ts
@@ -1,5 +1,6 @@
 import type { Event as ElectronEvent } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { handleBeforeQuit, handleMainWindowClose } from '../index'
 
 const context = vi.hoisted(() => {
   const appHandlers = new Map<string, (...args: unknown[]) => void>()
@@ -103,8 +104,6 @@ vi.mock('../windowBounds', () => ({
   DEFAULT_WINDOW_BOUNDS: {},
   normalizeWindowBounds: vi.fn(),
 }))
-
-const { handleBeforeQuit, handleMainWindowClose } = await import('../index')
 
 function createEvent(): ElectronEvent {
   return {


### PR DESCRIPTION
Fixes the v5.10.0 release build failure caused by a top-level await in the main lifecycle test while compiling the CommonJS main process.

Checks:
- pnpm test src/main/__tests__/mainLifecycle.test.ts
- pnpm exec eslint src/main/__tests__/mainLifecycle.test.ts
- pnpm build:main
- git diff --check